### PR TITLE
fix: escape quotes within link titles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,8 +568,7 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark-to-cmark"
 version = "11.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef5694118eae27ee8bff0832aa83bf70f9249e7750091165032ab5b09600fb6b"
+source = "git+https://github.com/max-heller/pulldown-cmark-to-cmark?branch=quotes-in-quotes#74f0abee0dcfde1148af57e2acc0451b12ce1308"
 dependencies = [
  "pulldown-cmark",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,8 +567,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark-to-cmark"
-version = "11.0.1"
-source = "git+https://github.com/max-heller/pulldown-cmark-to-cmark?branch=quotes-in-quotes#74f0abee0dcfde1148af57e2acc0451b12ce1308"
+version = "11.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a883e495f8fc4f209521b03a89dde6f6f211ed7cf92e85693c82508e8b722710"
 dependencies = [
  "pulldown-cmark",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ log = "0.4.0"
 mdbook = { version = "0.4.21", default-features = false }
 once_cell = "1.0.0"
 pulldown-cmark = { version = "0.9.0", default-features = false }
-pulldown-cmark-to-cmark = { version = "11.0.1", git = "https://github.com/max-heller/pulldown-cmark-to-cmark", branch = "quotes-in-quotes" }
+pulldown-cmark-to-cmark = "11.0.2"
 regex = "1.0.0"
 semver = "1.0.0"
 serde = { version = "1.0.85", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ log = "0.4.0"
 mdbook = { version = "0.4.21", default-features = false }
 once_cell = "1.0.0"
 pulldown-cmark = { version = "0.9.0", default-features = false }
-pulldown-cmark-to-cmark = "11.0.1"
+pulldown-cmark-to-cmark = { version = "11.0.1", git = "https://github.com/max-heller/pulldown-cmark-to-cmark", branch = "quotes-in-quotes" }
 regex = "1.0.0"
 semver = "1.0.0"
 serde = { version = "1.0.85", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -793,6 +793,31 @@ This is an example of a footnote[^note].
     }
 
     #[test]
+    fn link_title_containing_quotes() {
+        let book = MDBook::init()
+            .config(Config::latex())
+            .chapter(Chapter::new(
+                "",
+                r#"
+[link][link-with-description]
+
+[link-with-description]: chapter.md '"foo" (bar)'
+                "#,
+                "chapter.md",
+            ))
+            .build();
+        insta::assert_display_snapshot!(book, @r###"
+        ├─ log output
+        │  INFO mdbook::book: Running the pandoc backend    
+        │  INFO mdbook_pandoc::render: Wrote output to book/latex/output.tex    
+        ├─ latex/output.tex
+        │ \href{chapter.md}{link}
+        ├─ latex/src/chapter.md
+        │ [link](chapter.md "\"foo\" (bar)")
+        "###);
+    }
+
+    #[test]
     fn raw_opts() {
         let cfg = r#"
 [output.pandoc.profile.test]


### PR DESCRIPTION
Before, link titles that contained quotes would be rendered without their interior quotes escaped and preprocessing would turn
```md
[link](dest "\"weird title\"")
```
into
```md
[link](dest ""weird title"")
```
resulting in a broken link.

This was due to a bug in `pulldown-cmark-to-cmark` fixed in https://github.com/Byron/pulldown-cmark-to-cmark/pull/62 and released in version 11.0.2, so this PR bumps the version requirement.