### PR TITLE
chore: explicitly include files for cargo packaging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["mdbook", "pandoc", "pdf", "latex", "book"]
 documentation = "https://docs.rs/mdbook-pandoc"
 repository = "https://github.com/max-heller/mdbook-pandoc"
+include = ["/src", "/CHANGELOG.md", "/LICENSE-*", "/README.md"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Prevents `cargo package` from including unnecessary files, in particular the `books` subdirectory