### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,6 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
       - name: Install cargo-dist
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.5.0/cargo-dist-installer.sh | sh"
       # sure would be cool if github gave us proper conditionals...
@@ -102,8 +100,6 @@ jobs:
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
       - uses: swatinem/rust-cache@v2
       - name: Install cargo-dist
         run: ${{ matrix.install_dist }}
@@ -153,8 +149,6 @@ jobs:
       BUILD_MANIFEST_NAME: target/distrib/dist-manifest.json
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
       - name: Install cargo-dist
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.5.0/cargo-dist-installer.sh | sh"
       # Get all the local artifacts for the global tasks to use (for e.g. checksums)
@@ -197,8 +191,6 @@ jobs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
       - name: Install cargo-dist
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.5.0/cargo-dist-installer.sh | sh"
       # Fetch artifacts from scratch-storage
@@ -235,8 +227,6 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
       - name: "Download Github Artifacts"
         uses: actions/download-artifact@v3
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,6 @@ installers = ["shell", "powershell"]
 targets = ["x86_64-unknown-linux-gnu", "aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Publish jobs to run in CI
 pr-run-mode = "plan"
+# TODO: Remove once https://github.com/Swatinem/rust-cache/pull/180 is released
+# Allow modifications to generated CI workflow
+allow-dirty = ["ci"]


### PR DESCRIPTION
The `rust-cache` action in the release workflow currently breaks because this repo's submodules contain a lot of `Cargo.toml` and `Cargo.lock` files. This will be fixed by https://github.com/Swatinem/rust-cache/pull/180, but for now this PR disables cloning submodules during the release workflow.