### PR TITLE
Correctly identify profiles as LaTeX when output file is PDF and no PDF engine or output format is specified

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ impl PandocProfile {
                         true
                     }
                 }
-                None => false,
+                None => true,
             }
         };
         match (self.to.as_deref(), self.output.extension()) {


### PR DESCRIPTION
When no PDF engine or output format is specified, pandoc [defaults to using LaTeX to create PDFs](https://pandoc.org/MANUAL.html#creating-a-pdf).