### PR TITLE
Syntax highlighting for Rust code blocks with mdBook attributes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -793,6 +793,51 @@ This is an example of a footnote[^note].
     }
 
     #[test]
+    fn mdbook_rust_code_block_attributes() {
+        let book = MDBook::init()
+            .config(Config::latex())
+            .chapter(Chapter::new(
+                "",
+                r#"
+```rust
+fn main() {}
+```
+```rust,ignore
+fn main() {}
+```
+                "#,
+                "chapter.md",
+            ))
+            .build();
+        insta::assert_display_snapshot!(book, @r###"
+        ├─ log output
+        │  INFO mdbook::book: Running the pandoc backend    
+        │  INFO mdbook_pandoc::render: Wrote output to book/latex/output.tex    
+        ├─ latex/output.tex
+        │ \begin{Shaded}
+        │ \begin{Highlighting}[]
+        │ \KeywordTok{fn}\NormalTok{ main() }\OperatorTok{\{\}}
+        │ \end{Highlighting}
+        │ \end{Shaded}
+        │ 
+        │ \begin{Shaded}
+        │ \begin{Highlighting}[]
+        │ \KeywordTok{fn}\NormalTok{ main() }\OperatorTok{\{\}}
+        │ \end{Highlighting}
+        │ \end{Shaded}
+        ├─ latex/src/chapter.md
+        │ 
+        │ ````rust
+        │ fn main() {}
+        │ ````
+        │ 
+        │ ````rust
+        │ fn main() {}
+        │ ````
+        "###);
+    }
+
+    #[test]
     fn link_title_containing_quotes() {
         let book = MDBook::init()
             .config(Config::latex())

--- a/src/snapshots/mdbook_pandoc__tests__nomicon.snap
+++ b/src/snapshots/mdbook_pandoc__tests__nomicon.snap
@@ -57,9 +57,9 @@ expression: logs
  WARN mdbook_pandoc::preprocess: Unable to normalize link '../core/panic/struct.PanicInfo.html' in chapter '#[panic_handler]': Unable to canonicalize path: $ROOT/src/../core/panic/struct.PanicInfo.html: No such file or directory (os error 2)    
 [WARNING] Missing character: There is no 🙀 (U+1F640) (U+1F640) in font [lmroman10-regular]:+tlig;
 [WARNING] Missing character: There is no ‒ (U+2012) (U+2012) in font [lmroman10-regular]:+tlig;!
-[WARNING] Missing character: There is no Ӛ (U+04DA) (U+04DA) in font SourceCodePro:mode=node;scrip
-[WARNING] Missing character: There is no 😿 (U+1F63F) (U+1F63F) in font SourceCodePro:mode=node;sc
-[WARNING] Missing character: There is no 😿 (U+1F63F) (U+1F63F) in font SourceCodePro:mode=node;sc
+[WARNING] Missing character: There is no Ӛ (U+04DA) (U+04DA) in font SourceCodePro/I:mode=node;scr
+[WARNING] Missing character: There is no 😿 (U+1F63F) (U+1F63F) in font SourceCodePro/I:mode=node;
+[WARNING] Missing character: There is no 😿 (U+1F63F) (U+1F63F) in font SourceCodePro/I:mode=node;
 [WARNING] Missing character: There is no ‒ (U+2012) (U+2012) in font [lmroman10-regular]:+tlig;!
  INFO mdbook_pandoc::render: Wrote output to book/pdf/book.pdf    
 

--- a/src/snapshots/mdbook_pandoc__tests__rust_by_example.snap
+++ b/src/snapshots/mdbook_pandoc__tests__rust_by_example.snap
@@ -6,9 +6,9 @@ expression: logs
  WARN mdbook_pandoc::preprocess: Unable to normalize link '../../reference/inline-assembly.html#abi-clobbers' in chapter 'Inline assembly': Unable to canonicalize path: $ROOT/src/unsafe/../../reference/inline-assembly.html: No such file or directory (os error 2)    
 [WARNING] Missing character: There is no 🛈 (U+1F6C8) (U+1F6C8) in font [lmroman10-regular]:+tlig;
 [WARNING] Missing character: There is no 🛈 (U+1F6C8) (U+1F6C8) in font [lmroman10-regular]:+tlig;
-[WARNING] Missing character: There is no よ (U+3088) (U+3088) in font SourceCodePro:mode=node;scri
-[WARNING] Missing character: There is no う (U+3046) (U+3046) in font SourceCodePro:mode=node;scri
-[WARNING] Missing character: There is no こ (U+3053) (U+3053) in font SourceCodePro:mode=node;scri
-[WARNING] Missing character: There is no そ (U+305D) (U+305D) in font SourceCodePro:mode=node;scri
+[WARNING] Missing character: There is no よ (U+3088) (U+3088) in font SourceCodePro/I:mode=node;sc
+[WARNING] Missing character: There is no う (U+3046) (U+3046) in font SourceCodePro/I:mode=node;sc
+[WARNING] Missing character: There is no こ (U+3053) (U+3053) in font SourceCodePro/I:mode=node;sc
+[WARNING] Missing character: There is no そ (U+305D) (U+305D) in font SourceCodePro/I:mode=node;sc
  INFO mdbook_pandoc::render: Wrote output to book/pdf/book.pdf    
 


### PR DESCRIPTION
Strips [mdBook attributes](https://rust-lang.github.io/mdBook/format/mdbook.html#rust-code-block-attributes) from Rust code blocks so they are interpreted as Rust code blocks by pandoc.