### PR TITLE
Allow configuring logging with `RUST_LOG` environment variable

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ fn main() {
 fn try_main() -> anyhow::Result<()> {
     env_logger::builder()
         .filter_level(log::LevelFilter::Info)
+        .parse_default_env()
         .init();
 
     let ctx = mdbook::renderer::RenderContext::from_json(io::stdin().lock())


### PR DESCRIPTION
Configures `env_logger` to parse the `RUST_LOG` environment variable to [determine which logs to emit](https://docs.rs/env_logger/latest/env_logger/#enabling-logging).