### PR TITLE
Decrease log level of ignored separator warning to DEBUG

### DIFF
--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -355,7 +355,7 @@ impl PreprocessedFiles<'_> {
                 Ok(Some(normalized.destination_relative_path))
             }
             BookItem::Separator => {
-                log::warn!("Ignoring separator");
+                log::debug!("Ignoring separator");
                 Ok(None)
             }
             BookItem::PartTitle(name) => {

--- a/src/snapshots/mdbook_pandoc__tests__mdbook_guide.snap
+++ b/src/snapshots/mdbook_pandoc__tests__mdbook_guide.snap
@@ -4,6 +4,5 @@ expression: logs
 ---
  INFO mdbook::book: Running the pandoc backend    
  INFO mdbook_pandoc: Processing redirects in [output.html.redirect]    
- WARN mdbook_pandoc::preprocess: Ignoring separator    
  INFO mdbook_pandoc::render: Wrote output to book/pdf/book.pdf    
 

--- a/src/snapshots/mdbook_pandoc__tests__rust_embedded.snap
+++ b/src/snapshots/mdbook_pandoc__tests__rust_embedded.snap
@@ -3,7 +3,6 @@ source: src/lib.rs
 expression: logs
 ---
  INFO mdbook::book: Running the pandoc backend    
- WARN mdbook_pandoc::preprocess: Ignoring separator    
 [WARNING] Missing character: There is no 🦀 (U+1F980) (U+1F980) in font [lmroman10-regular]:+tlig;
 [WARNING] Missing character: There is no ✓ (U+2713) (U+2713) in font [lmroman10-regular]:+tlig;!
 [WARNING] Missing character: There is no ✓ (U+2713) (U+2713) in font [lmroman10-regular]:+tlig;!

--- a/src/snapshots/mdbook_pandoc__tests__rustc_dev_guide.snap
+++ b/src/snapshots/mdbook_pandoc__tests__rustc_dev_guide.snap
@@ -8,7 +8,6 @@ expression: logs
  WARN mdbook::preprocess::cmd: 	Command: mdbook-toc    
  INFO mdbook::book: Running the pandoc backend    
  INFO mdbook_pandoc: Processing redirects in [output.html.redirect]    
- WARN mdbook_pandoc::preprocess: Ignoring separator    
  WARN mdbook_pandoc::preprocess: Heading (level h5) converted to paragraph in chapter: Coinduction    
  WARN mdbook_pandoc::preprocess: Heading (level h5) converted to paragraph in chapter: Coinduction    
  WARN mdbook_pandoc::preprocess: Heading (level h5) converted to paragraph in chapter: Return Position Impl Trait In Trait    
@@ -22,8 +21,6 @@ expression: logs
  WARN mdbook_pandoc::preprocess: Heading (level h5) converted to paragraph in chapter: Return Position Impl Trait In Trait    
  WARN mdbook_pandoc::preprocess: Heading (level h5) converted to paragraph in chapter: Return Position Impl Trait In Trait    
  WARN mdbook_pandoc::preprocess: Heading (level h5) converted to paragraph in chapter: Return Position Impl Trait In Trait    
- WARN mdbook_pandoc::preprocess: Ignoring separator    
- WARN mdbook_pandoc::preprocess: Ignoring separator    
 Error producing PDF.
 ! LaTeX Error: Too deeply nested.
 


### PR DESCRIPTION
Separators (see [here](https://rust-lang.github.io/mdBook/format/summary.html#structure)) are used only to render lines dividing the table of contents. We may want to do something with them in the future, but ignoring them isn't particularly important to report