### PR TITLE
Run `pandoc` with mdBook root as working directory

### DIFF
--- a/src/snapshots/mdbook_pandoc__tests__cargo_book.snap
+++ b/src/snapshots/mdbook_pandoc__tests__cargo_book.snap
@@ -165,11 +165,11 @@ expression: logs
  WARN mdbook_pandoc::preprocess: Unable to normalize link '../../edition-guide/index.html' in chapter 'Appendix: Glossary': Unable to canonicalize path: $ROOT/src/appendix/../../edition-guide/index.html: No such file or directory (os error 2)    
  WARN mdbook_pandoc::preprocess: Unable to normalize link '../../reference/attributes/codegen.html#the-target_feature-attribute' in chapter 'Appendix: Glossary': Unable to canonicalize path: $ROOT/src/appendix/../../reference/attributes/codegen.html: No such file or directory (os error 2)    
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `commands__cargomd__option-cargo---offline' on page 265
-  undefined on input line 18998.
+  `book__pdf__src__commands__cargomd__option-cargo---offline'
+  on page 265 undefined on input line 19222.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `commands__cargo-buildmd__option-cargo-build---keep-going'
-  on page 269 undefined on input line 19223.
+  `book__pdf__src__commands__cargo-buildmd__option-cargo-build---keep-going'
+  on page 269 undefined on input line 19459.
 [WARNING] [makePDF] LaTeX Warning: There were undefined references.
 [WARNING] Missing character: There is no ɑ (U+0251) (U+0251) in font [lmroman10-regular]:+tlig;!
  INFO mdbook_pandoc::render: Wrote output to book/pdf/book.pdf    

--- a/src/snapshots/mdbook_pandoc__tests__rust_book.snap
+++ b/src/snapshots/mdbook_pandoc__tests__rust_book.snap
@@ -37,17 +37,17 @@ expression: logs
  WARN mdbook_pandoc::preprocess: Unable to normalize link '../reference/items/unions.html' in chapter 'A - Keywords': Unable to canonicalize path: $ROOT/src/../reference/items/unions.html: No such file or directory (os error 2)    
  WARN mdbook_pandoc::preprocess: Unable to normalize link '../std/index.html' in chapter 'C - Derivable Traits': Unable to canonicalize path: $ROOT/src/../std/index.html: No such file or directory (os error 2)    
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `ch15-02-derefmd__following-the-pointer-to-the-value-with-the-dereference-operator'
-  on page 181 undefined on input line 10842.
+  `book__pdf__src__ch15-02-derefmd__following-the-pointer-to-the-value-with-the-dereference-operator'
+  on page 181 undefined on input line 10865.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `ch06-02-matchmd__the-match-control-flow-operator' on page
-  566 undefined on input line 33682.
+  `book__pdf__src__ch06-02-matchmd__the-match-control-flow-operator'
+  on page 566 undefined on input line 33717.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `ch13-01-closuresmd__moving-captured-values-out-of-the-closure-and-the-fn-traits'
-  on page 606 undefined on input line 36050.
+  `book__pdf__src__ch13-01-closuresmd__moving-captured-values-out-of-the-closure-and-the-fn-traits'
+  on page 606 undefined on input line 36087.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `ch04-01-what-is-ownershipmd__ways-variables-and-data-interact-clone'
-  on page 654 undefined on input line 38865.
+  `book__pdf__src__ch04-01-what-is-ownershipmd__ways-variables-and-data-interact-clone'
+  on page 654 undefined on input line 38904.
 [WARNING] [makePDF] LaTeX Warning: There were undefined references.
 [WARNING] Missing character: There is no 🚨 (U+1F6A8) (U+1F6A8) in font [lmroman10-bold]:+tlig;!
 [WARNING] Missing character: There is no 👍 (U+1F44D) (U+1F44D) in font SourceCodePro:mode=node;sc

--- a/src/snapshots/mdbook_pandoc__tests__rust_embedded.snap
+++ b/src/snapshots/mdbook_pandoc__tests__rust_embedded.snap
@@ -4,29 +4,29 @@ expression: logs
 ---
  INFO mdbook::book: Running the pandoc backend    
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `design-patterns__hal__namingmd__c-crate-name' on page 95
-  undefined on input line 5740.
+  `book__pdf__src__design-patterns__hal__namingmd__c-crate-name'
+  on page 95 undefined on input line 5763.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `design-patterns__hal__interoperabilitymd__c-free' on page
-  95 undefined on input line 5750.
+  `book__pdf__src__design-patterns__hal__interoperabilitymd__c-free'
+  on page 95 undefined on input line 5773.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `design-patterns__hal__interoperabilitymd__c-reexport-pac'
-  on page 95 undefined on input line 5753.
+  `book__pdf__src__design-patterns__hal__interoperabilitymd__c-reexport-pac'
+  on page 95 undefined on input line 5776.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `design-patterns__hal__interoperabilitymd__c-hal-traits' on
-  page 95 undefined on input line 5756.
+  `book__pdf__src__design-patterns__hal__interoperabilitymd__c-hal-traits'
+  on page 95 undefined on input line 5779.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `design-patterns__hal__predictabilitymd__c-ctor' on page 95
-  undefined on input line 5766.
+  `book__pdf__src__design-patterns__hal__predictabilitymd__c-ctor'
+  on page 95 undefined on input line 5789.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `design-patterns__hal__gpiomd__c-zst-pin' on page 95
-  undefined on input line 5776.
+  `book__pdf__src__design-patterns__hal__gpiomd__c-zst-pin' on
+  page 95 undefined on input line 5799.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `design-patterns__hal__gpiomd__c-erased-pin' on page 95
-  undefined on input line 5779.
+  `book__pdf__src__design-patterns__hal__gpiomd__c-erased-pin'
+  on page 95 undefined on input line 5802.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `design-patterns__hal__gpiomd__c-pin-state' on page 95
-  undefined on input line 5782.
+  `book__pdf__src__design-patterns__hal__gpiomd__c-pin-state'
+  on page 95 undefined on input line 5805.
 [WARNING] [makePDF] LaTeX Warning: There were undefined references.
 [WARNING] Missing character: There is no 🦀 (U+1F980) (U+1F980) in font [lmroman10-regular]:+tlig;
 [WARNING] Missing character: There is no ✓ (U+2713) (U+2713) in font [lmroman10-regular]:+tlig;!

--- a/src/snapshots/mdbook_pandoc__tests__rust_reference.snap
+++ b/src/snapshots/mdbook_pandoc__tests__rust_reference.snap
@@ -195,38 +195,47 @@ expression: logs
  WARN mdbook_pandoc::preprocess: Unable to normalize link '../std/panic/fn.set_hook.html' in chapter 'The Rust runtime': Unable to canonicalize path: $ROOT/src/../std/panic/fn.set_hook.html: No such file or directory (os error 2)    
  WARN mdbook_pandoc::preprocess: Unable to normalize link '../alloc/alloc/trait.GlobalAlloc.html' in chapter 'The Rust runtime': Unable to canonicalize path: $ROOT/src/../alloc/alloc/trait.GlobalAlloc.html: No such file or directory (os error 2)    
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `type-layoutmd__the-default-representation' on page 81
-  undefined on input line 5266.
+  `book__pdf__src__type-layoutmd__the-default-representation'
+  on page 81 undefined on input line 5399.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `statementsmd__let-else-restriction' on page 154 undefined
-  on input line 10444.
+  `book__pdf__src__items__enumerationsmd__unit-only-enum' on
+  page 81 undefined on input line 5418.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `items__enumerationsmd__unit-only-enum' on page 179
-  undefined on input line 12359.
+  `book__pdf__src__items__enumerationsmd__unit-only-enum' on
+  page 83 undefined on input line 5514.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `items__enumerationsmd__field-less-enum' on page 179
-  undefined on input line 12361.
+  `book__pdf__src__items__enumerationsmd__field-less-enum' on
+  page 83 undefined on input line 5535.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `type-layoutmd__the-rust-representation' on page 253
-  undefined on input line 17561.
+  `book__pdf__src__statementsmd__let-else-restriction' on page
+  154 undefined on input line 10681.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `type-layoutmd__the-rust-representation' on page 253
-  undefined on input line 17591.
+  `book__pdf__src__items__enumerationsmd__unit-only-enum' on
+  page 179 undefined on input line 12652.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `items__enumerationsmd__field-less-enum' on page 257
-  undefined on input line 17819.
+  `book__pdf__src__items__enumerationsmd__field-less-enum' on
+  page 179 undefined on input line 12655.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `items__enumerationsmd__field-less-enum' on page 257
-  undefined on input line 17832.
+  `book__pdf__src__type-layoutmd__the-rust-representation' on
+  page 253 undefined on input line 18013.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `items__enumerationsmd__field-less-enum' on page 257
-  undefined on input line 17837.
+  `book__pdf__src__type-layoutmd__the-rust-representation' on
+  page 253 undefined on input line 18044.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `items__enumerationsmd__field-less-enum' on page 258
-  undefined on input line 17944.
+  `book__pdf__src__items__enumerationsmd__field-less-enum' on
+  page 257 undefined on input line 18275.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `type-layoutmd__the-rust-representation' on page 261
-  undefined on input line 18119.
+  `book__pdf__src__items__enumerationsmd__field-less-enum' on
+  page 257 undefined on input line 18288.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pdf__src__items__enumerationsmd__field-less-enum' on
+  page 257 undefined on input line 18293.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pdf__src__items__enumerationsmd__field-less-enum' on
+  page 258 undefined on input line 18401.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pdf__src__type-layoutmd__the-rust-representation' on
+  page 261 undefined on input line 18576.
 [WARNING] [makePDF] LaTeX Warning: There were undefined references.
 [WARNING] Missing character: There is no 東 (U+6771) (U+6771) in font SourceCodePro:mode=node;scri
 [WARNING] Missing character: There is no 京 (U+4EAC) (U+4EAC) in font SourceCodePro:mode=node;scri

--- a/src/snapshots/mdbook_pandoc__tests__rustc_dev_guide.snap
+++ b/src/snapshots/mdbook_pandoc__tests__rustc_dev_guide.snap
@@ -28,7 +28,7 @@ See the LaTeX manual or LaTeX Companion for explanation.
 Type  H <return>  for immediate help.
  ...                                              
                                                   
-l.11738         \begin{itemize}
+l.11936         \begin{itemize}
 
 Rendering failed: pandoc exited unsuccessfully
 


### PR DESCRIPTION
Sets the working directory for `pandoc` to the mdBook root directory instead of the destination directory, which makes more sense when passing filenames to Pandoc through options like [`--include-in-header`](https://pandoc.org/MANUAL.html#option--include-in-header).