### PR TITLE
Support lists nested more than four levels deep when rendering to LaTeX

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,6 @@ artifacts = [
   "rendered-rust-edition-guide.pdf",
   "rendered-rust-embedded.pdf",
   "rendered-rust-reference.pdf",
-  # Currently fails to build
-  # "rendered-rustc-dev-guide.pdf",
+  "rendered-rustc-dev-guide.pdf",
 ]
 build = ["bash", "-c", "git submodule update --init && source scripts/install-ci-deps && ./scripts/cargo-dist-render-books"]

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ PDFs are rendered with LaTeX ([xelatex](https://en.wikipedia.org/wiki/XeTeX)).
 | [Rust Edition Guide](https://doc.rust-lang.org/edition-guide/) | [PDF](https://github.com/max-heller/mdbook-pandoc/releases/latest/download/rendered-rust-edition-guide.pdf) |
 | [Embedded Rust Book](https://docs.rust-embedded.org/book/) | [PDF](https://github.com/max-heller/mdbook-pandoc/releases/latest/download/rendered-rust-embedded.pdf) |
 | [Rust Reference](https://doc.rust-lang.org/reference/) | [PDF](https://github.com/max-heller/mdbook-pandoc/releases/latest/download/rendered-rust-reference.pdf) |
-| [Rust Compiler Development Guide](https://rustc-dev-guide.rust-lang.org/) | ❌ Compilation fails |
+| [Rust Compiler Development Guide](https://rustc-dev-guide.rust-lang.org/) | [PDF](https://github.com/max-heller/mdbook-pandoc/releases/latest/download/rendered-rustc-dev-guide.pdf) |
 
 #### Rendering to PDF
 

--- a/scripts/cargo-dist-render-books
+++ b/scripts/cargo-dist-render-books
@@ -14,5 +14,4 @@ cp books/rust-by-example/book/pdf/book.pdf rendered-rust-by-example.pdf
 cp books/rust-edition-guide/book/pdf/book.pdf rendered-rust-edition-guide.pdf
 cp books/rust-embedded/book/pdf/book.pdf rendered-rust-embedded.pdf
 cp books/rust-reference/book/pdf/book.pdf rendered-rust-reference.pdf
-# Currently fails to build
-# cp books/rustc-dev-guide/book/pdf/book.pdf rendered-rustc-dev-guide.pdf
+cp books/rustc-dev-guide/book/pandoc/pdf/book.pdf rendered-rustc-dev-guide.pdf

--- a/src/latex.rs
+++ b/src/latex.rs
@@ -8,6 +8,7 @@ pub struct Packages {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Package {
     FontAwesome,
+    EnumItem,
 }
 
 impl Packages {
@@ -24,6 +25,7 @@ impl Package {
     pub fn name(&self) -> &str {
         match self {
             Self::FontAwesome => "fontawesome",
+            Self::EnumItem => "enumitem",
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,8 @@ impl mdbook::Renderer for Renderer {
                 pandoc: pandoc::Context::new(pandoc_version.clone()),
                 destination: book.destination.join(name),
                 output: profile.output_format(),
+                cur_list_depth: 0,
+                max_list_depth: 0,
             };
 
             // Preprocess book

--- a/src/pandoc/renderer.rs
+++ b/src/pandoc/renderer.rs
@@ -1,6 +1,7 @@
 use std::{
     borrow::Cow,
-    fmt, fs,
+    fmt::{self, Write},
+    fs, iter,
     path::{Path, PathBuf},
     process::{Command, Stdio},
 };
@@ -22,6 +23,8 @@ pub struct Context<'book> {
     pub pandoc: pandoc::Context,
     pub destination: PathBuf,
     pub book: &'book Book<'book>,
+    pub cur_list_depth: usize,
+    pub max_list_depth: usize,
 }
 
 pub enum OutputFormat {
@@ -51,7 +54,7 @@ impl Renderer {
         self
     }
 
-    pub fn render(self, profile: Profile, ctx: &Context) -> anyhow::Result<()> {
+    pub fn render(self, profile: Profile, ctx: &mut Context) -> anyhow::Result<()> {
         let Profile {
             columns,
             file_scope,
@@ -117,8 +120,48 @@ impl Renderer {
         }
 
         let mut additional_variables: Vec<(_, Cow<str>)> = vec![];
-        match &ctx.output {
+        match &mut ctx.output {
             OutputFormat::Latex { packages } => {
+                // https://www.overleaf.com/learn/latex/Lists#Lists_for_lawyers:_nesting_lists_to_an_arbitrary_depth
+                const LATEX_DEFAULT_LIST_DEPTH_LIMIT: usize = 4;
+
+                // If necessary, extend the max list depth
+                if ctx.max_list_depth > LATEX_DEFAULT_LIST_DEPTH_LIMIT {
+                    packages.need(latex::Package::EnumItem);
+
+                    let mut include_before = format!(
+                        // Source: https://tex.stackexchange.com/a/41409 and https://tex.stackexchange.com/a/304515
+                        r"
+\setlistdepth{{{depth}}}
+\renewlist{{itemize}}{{itemize}}{{{depth}}}
+
+% initially, use dots for all levels
+\setlist[itemize]{{label=$\cdot$}}
+
+% customize the first 3 levels
+\setlist[itemize,1]{{label=\textbullet}}
+\setlist[itemize,2]{{label=--}}
+\setlist[itemize,3]{{label=*}}
+
+\renewlist{{enumerate}}{{enumerate}}{{{depth}}}
+                        ",
+                        depth = ctx.max_list_depth,
+                    );
+
+                    let enumerate_labels =
+                        iter::repeat([r"\arabic*", r"\Roman*", r"\Alph*", r"\roman*", r"\alph*"])
+                            .flatten();
+                    for (idx, label) in enumerate_labels.take(ctx.max_list_depth).enumerate() {
+                        writeln!(
+                            include_before,
+                            r"\setlist[enumerate,{}]{{label=({label})}}",
+                            idx + 1,
+                        )
+                        .unwrap();
+                    }
+                    additional_variables.push(("include-before", include_before.into()))
+                }
+
                 let include_packages = packages
                     .needed()
                     .map(|package| format!(r"\usepackage{{{}}}", package.name()))

--- a/src/pandoc/renderer.rs
+++ b/src/pandoc/renderer.rs
@@ -1,7 +1,7 @@
 use std::{
     borrow::Cow,
     fmt::{self, Write},
-    fs, iter,
+    fs,
     path::{Path, PathBuf},
     process::{Command, Stdio},
 };
@@ -144,13 +144,14 @@ impl Renderer {
 \setlist[itemize,3]{{label=*}}
 
 \renewlist{{enumerate}}{{enumerate}}{{{depth}}}
-                        ",
+",
                         depth = ctx.max_list_depth,
                     );
 
                     let enumerate_labels =
-                        iter::repeat([r"\arabic*", r"\Roman*", r"\Alph*", r"\roman*", r"\alph*"])
-                            .flatten();
+                        [r"\arabic*", r"\alph*", r"\roman*", r"\Alph*", r"\Roman*"]
+                            .into_iter()
+                            .cycle();
                     for (idx, label) in enumerate_labels.take(ctx.max_list_depth).enumerate() {
                         writeln!(
                             include_before,

--- a/src/snapshots/mdbook_pandoc__tests__rustc_dev_guide.snap
+++ b/src/snapshots/mdbook_pandoc__tests__rustc_dev_guide.snap
@@ -21,14 +21,253 @@ expression: logs
  WARN mdbook_pandoc::preprocess: Heading (level h5) converted to paragraph in chapter: Return Position Impl Trait In Trait    
  WARN mdbook_pandoc::preprocess: Heading (level h5) converted to paragraph in chapter: Return Position Impl Trait In Trait    
  WARN mdbook_pandoc::preprocess: Heading (level h5) converted to paragraph in chapter: Return Position Impl Trait In Trait    
-Error producing PDF.
-! LaTeX Error: Too deeply nested.
-
-See the LaTeX manual or LaTeX Companion for explanation.
-Type  H <return>  for immediate help.
- ...                                              
-                                                  
-l.11936         \begin{itemize}
-
-Rendering failed: pandoc exited unsuccessfully
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__glossarymd__ice' on page
+  26 undefined on input line 1326.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__conventionsmd__formatting' on page
+  40 undefined on input line 2347.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__tests__addingmd__explanatory_comment'
+  on page 50 undefined on input line 3156.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__building__how-to-build-and-runmd__toolchain'
+  on page 99 undefined on input line 6540.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__gitmd__conflicts' on page 124
+  undefined on input line 8184.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__walkthroughmd__impl' on page 137
+  undefined on input line 8798.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__conventionsmd__formatting' on page
+  155 undefined on input line 9782.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__conventionsmd__cc' on page 155
+  undefined on input line 9784.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__conventionsmd__cio' on page 155
+  undefined on input line 9786.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__conventionsmd__er' on page 155
+  undefined on input line 9788.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__notification-groups__aboutmd__join'
+  on page 178 undefined on input line 10754.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__notification-groups__aboutmd__join'
+  on page 178 undefined on input line 10759.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__glossarymd__intrinsic' on
+  page 203 undefined on input line 12298.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__queries__incremental-compilationmd__dag'
+  on page 219 undefined on input line 13422.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__querymd__adding-a-new-kind-of-query'
+  on page 229 undefined on input line 14010.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__generic_argumentsmd__GenericArgs'
+  on page 239 undefined on input line 14627.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__backgroundmd__cfg' on
+  page 297 undefined on input line 18070.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__backgroundmd__cfg' on
+  page 297 undefined on input line 18098.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__mir__indexmd__promoted' on page 300
+  undefined on input line 18333.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__glossarymd__newtype' on
+  page 301 undefined on input line 18346.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__glossarymd__newtype' on
+  page 301 undefined on input line 18356.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__glossarymd__newtype' on
+  page 301 undefined on input line 18376.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__glossarymd__placeholder'
+  on page 360 undefined on input line 22085.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__variancemd__addendum' on page 396
+  undefined on input line 24803.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__opaque-types-impl-trait-inferencemd__Within-the-type_of-query'
+  on page 403 undefined on input line 25349.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__glossarymd__region' on
+  page 431 undefined on input line 26822.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__glossarymd__inf-var' on
+  page 431 undefined on input line 26825.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__backgroundmd__dataflow'
+  on page 431 undefined on input line 26829.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__backgroundmd__free-vs-bound'
+  on page 439 undefined on input line 27421.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__glossarymd__point' on
+  page 443 undefined on input line 27823.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__borrow_check__region_inference__member_constraintsmd__collecting'
+  on page 451 undefined on input line 28388.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__backgroundmd__quantified'
+  on page 452 undefined on input line 28492.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__backgroundmd__variance'
+  on page 452 undefined on input line 28514.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__backgroundmd__free-vs-bound'
+  on page 453 undefined on input line 28564.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__diagnosticsmd__future-incompatible'
+  on page 468 undefined on input line 29517.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__glossarymd__mono' on page
+  506 undefined on input line 32190.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__glossarymd__def-id' on
+  page 506 undefined on input line 32204.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__glossarymd__codegen-unit'
+  on page 519 undefined on input line 32928.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__backgroundmd__cfg' on
+  page 572 undefined on input line 36232.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__backgroundmd__free-vs-bound'
+  on page 578 undefined on input line 36590.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__backgroundmd__free-vs-bound'
+  on page 578 undefined on input line 36600.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__backgroundmd__cfg' on
+  page 578 undefined on input line 36614.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__glossarymd__TyCtxt' on
+  page 578 undefined on input line 36622.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__glossarymd__cx' on page
+  578 undefined on input line 36623.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__glossarymd__tcx' on page
+  578 undefined on input line 36624.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__backgroundmd__dataflow'
+  on page 578 undefined on input line 36632.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__backgroundmd__what-is-a-debruijn-index'
+  on page 578 undefined on input line 36637.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__glossarymd__variant-idx'
+  on page 578 undefined on input line 36648.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__glossarymd__tag' on page
+  578 undefined on input line 36650.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__backgroundmd__free-vs-bound'
+  on page 578 undefined on input line 36682.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__glossarymd__tag' on page
+  578 undefined on input line 36797.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__traits__goals-and-clausesmd__trait-ref'
+  on page 578 undefined on input line 36827.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__mir__indexmd__promoted' on page 578
+  undefined on input line 36830.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__backgroundmd__quantified'
+  on page 578 undefined on input line 36838.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__glossarymd__discriminant'
+  on page 578 undefined on input line 36893.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__glossarymd__niche' on
+  page 578 undefined on input line 36896.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__traits__goals-and-clausesmd__trait-ref'
+  on page 578 undefined on input line 36920.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__glossarymd__tcx' on page
+  578 undefined on input line 36928.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__backgroundmd__variance'
+  on page 578 undefined on input line 36947.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__glossarymd__discriminant'
+  on page 578 undefined on input line 36953.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__hirmd__hir-id' on page 581
+  undefined on input line 36983.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__hirmd__hir-id' on page 581
+  undefined on input line 36999.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__hirmd__hir-id' on page 581
+  undefined on input line 37011.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__hirmd__hir-id' on page 581
+  undefined on input line 37016.
+[WARNING] [makePDF] LaTeX Warning: There were undefined references.
+[WARNING] Missing character: There is no   (U+2003) (U+2003) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no   (U+2003) (U+2003) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no   (U+2003) (U+2003) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no   (U+2003) (U+2003) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no   (U+2003) (U+2003) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no   (U+2003) (U+2003) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no   (U+2003) (U+2003) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no   (U+2003) (U+2003) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no   (U+2003) (U+2003) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no   (U+2003) (U+2003) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no   (U+2003) (U+2003) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no   (U+2003) (U+2003) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no   (U+2003) (U+2003) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no   (U+2003) (U+2003) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no   (U+2003) (U+2003) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no   (U+2003) (U+2003) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no   (U+2003) (U+2003) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no   (U+2003) (U+2003) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no   (U+2003) (U+2003) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no   (U+2003) (U+2003) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no   (U+2003) (U+2003) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no   (U+2003) (U+2003) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no   (U+2003) (U+2003) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no   (U+2003) (U+2003) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no   (U+2003) (U+2003) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no   (U+2003) (U+2003) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no   (U+2003) (U+2003) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no   (U+2003) (U+2003) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no   (U+2003) (U+2003) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no ‒ (U+2012) (U+2012) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no ‒ (U+2012) (U+2012) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no ‒ (U+2012) (U+2012) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no ‒ (U+2012) (U+2012) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no ‒ (U+2012) (U+2012) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no ‒ (U+2012) (U+2012) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no ‒ (U+2012) (U+2012) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no ✅ (U+2705) (U+2705) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no ❌ (U+274C) (U+274C) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no ✅ (U+2705) (U+2705) in font [lmroman10-bold]:+tlig;!
+[WARNING] Missing character: There is no ✅ (U+2705) (U+2705) in font [lmroman10-bold]:+tlig;!
+[WARNING] Missing character: There is no ❌ (U+274C) (U+274C) in font [lmroman10-bold]:+tlig;!
+[WARNING] Missing character: There is no ✅ (U+2705) (U+2705) in font [lmroman10-bold]:+tlig;!
+[WARNING] Missing character: There is no ✅ (U+2705) (U+2705) in font [lmroman10-bold]:+tlig;!
+[WARNING] Missing character: There is no ✅ (U+2705) (U+2705) in font [lmroman10-bold]:+tlig;!
+[WARNING] Missing character: There is no ✅ (U+2705) (U+2705) in font [lmroman10-bold]:+tlig;!
+[WARNING] Missing character: There is no ❌ (U+274C) (U+274C) in font [lmroman10-bold]:+tlig;!
+[WARNING] Missing character: There is no ✅ (U+2705) (U+2705) in font [lmroman10-bold]:+tlig;!
+[WARNING] Missing character: There is no ✅ (U+2705) (U+2705) in font [lmroman10-bold]:+tlig;!
+[WARNING] Missing character: There is no ❌ (U+274C) (U+274C) in font [lmroman10-bold]:+tlig;!
+[WARNING] Missing character: There is no ✅ (U+2705) (U+2705) in font [lmroman10-bold]:+tlig;!
+[WARNING] Missing character: There is no ⊇ (U+2287) (U+2287) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no ✅ (U+2705) (U+2705) in font SourceCodePro:mode=node;scri
+[WARNING] Missing character: There is no ✅ (U+2705) (U+2705) in font SourceCodePro:mode=node;scri
+[WARNING] Missing character: There is no ∀ (U+2200) (U+2200) in font [lmroman10-regular]:+tlig;!
+[WARNING] Missing character: There is no ∃ (U+2203) (U+2203) in font [lmroman10-regular]:+tlig;!
+ INFO mdbook_pandoc::pandoc::renderer: Wrote output to book/pandoc/pdf/book.pdf    
 


### PR DESCRIPTION
LaTeX by default can't handle lists with more than four levels of items. If necessary to render the book, this adds a dependency on the `enumitem` package to support more nested lists.