### PR TITLE
Pass options to Pandoc as defaults file instead of command-line arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,6 +358,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,6 +406,16 @@ checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -508,6 +530,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_derive",
+ "serde_yaml",
  "tempfile",
  "toml",
  "tracing",
@@ -818,6 +841,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1bf28c79a99f70ee1f1d83d10c875d2e70618417fda01ad1785e027579d9d38"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1048,6 +1084,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,14 @@ regex = "1.0.0"
 semver = "1.0.0"
 serde = { version = "1.0.85", features = ["derive"] }
 serde_derive = "1.0.85"
+serde_yaml = "0.9.0"
+tempfile = "3.0.0"
 toml = "0.5.0"
 ureq = "2.0.0"
 walkdir = "2.0.0"
 
 [dev-dependencies]
 insta = { version = "1.0.0" }
-tempfile = "3.0.0"
 tracing = { version = "0.1.0", default-features = false, features = ["std"] }
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["fmt", "tracing-log"] }

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To generate other output formats, see [Configuration](#configuration).
 title = "My First Book"
 
 + [output.pandoc.profile.pdf]
-+ output = "output.pdf"
++ output-file = "output.pdf"
 + to = "latex"
 ```
 
@@ -54,10 +54,10 @@ Running `mdbook build` will write the rendered book to `pdf/output.pdf` in `mdbo
 
 Since `mdbook-pandoc` supports many different output formats through `pandoc`, it must be configured to render to one or more formats through the `[output.pandoc]` table in a book's `book.toml` file.
 
-Configuration is centered around *output profiles*, named sets of arguments that `mdbook-pandoc` passes to `pandoc` to render a book in a particular format.
+Configuration is centered around *output profiles*, named packages of options that `mdbook-pandoc` passes to `pandoc` as a [*defaults file*](https://pandoc.org/MANUAL.html#defaults-files) to render a book in a particular format.
 The output for each profile is written to a subdirectory with the same name as the profile under `mdbook-pandoc`'s top-level [build directory](https://rust-lang.github.io/mdBook/format/configuration/renderers.html#output-tables) (`book/pandoc` if multiple renderers are configured; `book` otherwise).
 
-The available settings are described below:
+A subset of the available options are described below:
 
 > **Note:** Pandoc is run from the book's root directory (the directory containing `book.toml`).
 > Therefore, relative paths in the configuration (e.g. values for `include-in-header`, `reference-doc`) should be written relative to the book's root directory.
@@ -65,23 +65,23 @@ The available settings are described below:
 ```toml
 [output.pandoc]
 
-[output.pandoc.profile.<name>] # set of arguments to pass to `pandoc` (see https://pandoc.org/MANUAL.html)
-output = "output.pdf" # output file (within the profile's build directory)
+[output.pandoc.profile.<name>] # options to pass to Pandoc (see https://pandoc.org/MANUAL.html#defaults-files)
+output-file = "output.pdf" # output file (within the profile's build directory)
 to = "latex" # output format
 
 # PDF-specific settings
 pdf-engine = "pdflatex" # engine to use to produce PDF output
 
-# The following settings have sane defaults and should usually not need to be overridden
-columns = 72 # line length in characters
+# `mdbook-pandoc` overrides Pandoc's defaults for the following options to better support mdBooks
 file-scope = true # parse each file individually before combining
 number-sections = true # number sections headings
 standalone = true # produce output with an appropriate header and footer
 table-of-contents = true # include an automatically generated table of contents
-toc-depth = 3 # number of section levels to include in table of contents
 
-# Arbitrary other arguments to pass directly to `pandoc`...
+# Arbitrary other Pandoc options can be specified as they would be in a Pandoc defaults file
+# (see https://pandoc.org/MANUAL.html#defaults-files) but written in TOML instead of YAML...
 
+# For example, to pass variables (https://pandoc.org/MANUAL.html#variables):
 [output.pandoc.profile.<name>.variables]
 # Set the pandoc variable named 'variable-name' to 'value'
 variable-name = "value"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -449,15 +449,13 @@ mod tests {
     impl pandoc::Profile {
         fn latex() -> Self {
             Self {
-                columns: None,
                 file_scope: true,
                 number_sections: true,
-                output: PathBuf::from("output.tex"),
+                output_file: PathBuf::from("output.tex"),
                 pdf_engine: None,
                 standalone: false,
                 to: Some("latex".into()),
                 table_of_contents: true,
-                toc_depth: None,
                 variables: FromIterator::from_iter([("documentclass".into(), "report".into())]),
                 rest: Default::default(),
             }
@@ -465,10 +463,9 @@ mod tests {
 
         fn pdf() -> Self {
             Self {
-                columns: None,
                 file_scope: true,
                 number_sections: true,
-                output: "book.pdf".into(),
+                output_file: "book.pdf".into(),
                 pdf_engine: Some(
                     env::var_os("PDF_ENGINE")
                         .map(Into::into)
@@ -477,7 +474,6 @@ mod tests {
                 standalone: true,
                 to: Some("latex".into()),
                 table_of_contents: true,
-                toc_depth: None,
                 variables: FromIterator::from_iter([
                     ("documentclass".into(), "report".into()),
                     ("mainfont".into(), "Noto Serif".into()),
@@ -490,15 +486,13 @@ mod tests {
 
         fn markdown() -> Self {
             Self {
-                columns: None,
                 file_scope: true,
                 number_sections: true,
-                output: PathBuf::from("book.md"),
+                output_file: PathBuf::from("book.md"),
                 pdf_engine: None,
                 standalone: false,
                 to: Some("markdown".into()),
                 table_of_contents: true,
-                toc_depth: None,
                 variables: Default::default(),
                 rest: Default::default(),
             }
@@ -832,9 +826,9 @@ fn main() {}
     fn raw_opts() {
         let cfg = r#"
 [output.pandoc.profile.test]
-output = "/dev/null"
+output-file = "/dev/null"
 to = "markdown"
-verbose = true
+verbosity = "INFO"
 fail-if-warnings = false
 
 resource-path = [
@@ -860,7 +854,7 @@ colorlinks = false
         │ DEBUG mdbook::book: Running the index preprocessor.    
         │ DEBUG mdbook::book: Running the links preprocessor.    
         │  INFO mdbook::book: Running the pandoc backend    
-        │ DEBUG mdbook_pandoc::pandoc::renderer: Running: pandoc -f commonmark+gfm_auto_identifiers -o /dev/null -t markdown --file-scope -N -s --toc -V header-includes=text1 -V header-includes=text2 -V indent --resource-path=really-long-path --resource-path=really-long-path2 --verbose    
+        │ DEBUG mdbook_pandoc::pandoc::renderer: Running pandoc    
         │  INFO mdbook_pandoc::pandoc::renderer: Wrote output to /dev/null    
         "###)
     }
@@ -869,7 +863,7 @@ colorlinks = false
     fn redirects() {
         let cfg = r#"
 [output.pandoc.profile.test]
-output = "/dev/null"
+output-file = "/dev/null"
 to = "markdown"
 
 [output.html.redirect]
@@ -893,7 +887,7 @@ to = "markdown"
         │ DEBUG mdbook_pandoc::preprocess: Processing redirect: /new-bar.html => new-new-bar.html    
         │ DEBUG mdbook_pandoc::preprocess: Registered redirect: book/test/src/foo/bar.html => book/test/src/new-bar.html    
         │ DEBUG mdbook_pandoc::preprocess: Registered redirect: book/test/src/new-bar.html => book/test/src/new-new-bar.md    
-        │ DEBUG mdbook_pandoc::pandoc::renderer: Running: pandoc book/test/src/index.md book/test/src/new-new-bar.md -f commonmark+gfm_auto_identifiers -o /dev/null -t markdown --file-scope -N -s --toc    
+        │ DEBUG mdbook_pandoc::pandoc::renderer: Running pandoc    
         │  INFO mdbook_pandoc::pandoc::renderer: Wrote output to /dev/null    
         ├─ test/src/foo/bar.html
         ├─ test/src/index.md
@@ -932,7 +926,7 @@ to = "markdown"
     fn pandoc_working_dir_is_root() {
         let cfg = r#"
 [output.pandoc.profile.foo]
-output = "foo.md"
+output-file = "foo.md"
 include-in-header = ["file-in-root"]
         "#;
         let book = MDBook::init()

--- a/src/pandoc/profile.rs
+++ b/src/pandoc/profile.rs
@@ -7,19 +7,17 @@ use super::OutputFormat;
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Profile {
-    pub columns: Option<u16>,
     #[serde(default = "defaults::enabled")]
     pub file_scope: bool,
     #[serde(default = "defaults::enabled")]
     pub number_sections: bool,
-    pub output: PathBuf,
+    pub output_file: PathBuf,
     pub pdf_engine: Option<PathBuf>,
     #[serde(default = "defaults::enabled")]
     pub standalone: bool,
     pub to: Option<String>,
     #[serde(default = "defaults::enabled")]
     pub table_of_contents: bool,
-    pub toc_depth: Option<u8>,
     #[serde(default)]
     pub variables: BTreeMap<String, toml::Value>,
     #[serde(flatten)]
@@ -81,7 +79,7 @@ impl Profile {
                 None => true,
             }
         };
-        match (self.to.as_deref(), self.output.extension()) {
+        match (self.to.as_deref(), self.output_file.extension()) {
             (Some("latex"), _) => true,
             (Some("pdf"), _) => pdf_engine_is_latex(),
             (Some(_), _) => false,


### PR DESCRIPTION
As a result, some options must be specified with different names--in particular, `output` becomes `output-file`