### PR TITLE
feat: wrap long lines in code blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,6 +548,7 @@ dependencies = [
 name = "mdbook-pandoc"
 version = "0.5.0"
 dependencies = [
+ "aho-corasick",
  "anyhow",
  "env_logger",
  "genawaiter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ include = ["/src", "/CHANGELOG.md", "/LICENSE-*", "/README.md"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+aho-corasick = "1.0.0"
 anyhow = "1.0.47"
 env_logger = "0.11.0"
 genawaiter = { version = "0.99.1", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -869,6 +869,50 @@ This is an example of a footnote[^note].
     }
 
     #[test]
+    fn code_block_with_very_long_line() {
+        let long_line = str::repeat("long ", 1000);
+        let content = format!(
+            "
+```java
+{long_line}
+```
+            "
+        );
+        let book = MDBook::init()
+            .config(Config::pdf())
+            .chapter(Chapter::new("", content, "chapter.md"))
+            .build();
+        insta::assert_display_snapshot!(book, @r###"
+        ├─ log output
+        │  INFO mdbook::book: Running the pandoc backend    
+        │  INFO mdbook_pandoc::pandoc::renderer: Wrote output to book/pdf/book.pdf    
+        ├─ pdf/book.pdf
+        │ <INVALID UTF8>
+        "###);
+    }
+
+    #[test]
+    fn code_block_with_very_long_line_with_special_characters() {
+        let content = r#"""
+```console
+$ rustc json_error_demo.rs --error-format json
+{"message":"cannot add `&str` to `{integer}`","code":{"code":"E0277","explanation":"\nYou tried to use a type which doesn't implement some trait in a place which\nexpected that trait. Erroneous code example:\n\n```compile_fail,E0277\n// here we declare the Foo trait with a bar method\ntrait Foo {\n    fn bar(&self);\n}\n\n// we now declare a function which takes an object implementing the Foo trait\nfn some_func<T: Foo>(foo: T) {\n    foo.bar();\n}\n\nfn main() {\n    // we now call the method with the i32 type, which doesn't implement\n    // the Foo trait\n    some_func(5i32); // error: the trait bound `i32 : Foo` is not satisfied\n}\n```\n\nIn order to fix this error, verify that the type you're using does implement\nthe trait. Example:\n\n```\ntrait Foo {\n    fn bar(&self);\n}\n\nfn some_func<T: Foo>(foo: T) {\n    foo.bar(); // we can now use this method since i32 implements the\n               // Foo trait\n}\n\n// we implement the trait on the i32 type\nimpl Foo for i32 {\n    fn bar(&self) {}\n}\n\nfn main() {\n    some_func(5i32); // ok!\n}\n```\n\nOr in a generic context, an erroneous code example would look like:\n\n```compile_fail,E0277\nfn some_func<T>(foo: T) {\n    println!(\"{:?}\", foo); // error: the trait `core::fmt::Debug` is not\n                           //        implemented for the type `T`\n}\n\nfn main() {\n    // We now call the method with the i32 type,\n    // which *does* implement the Debug trait.\n    some_func(5i32);\n}\n```\n\nNote that the error here is in the definition of the generic function: Although\nwe only call it with a parameter that does implement `Debug`, the compiler\nstill rejects the function: It must work with all possible input types. In\norder to make this example compile, we need to restrict the generic type we're\naccepting:\n\n```\nuse std::fmt;\n\n// Restrict the input type to types that implement Debug.\nfn some_func<T: fmt::Debug>(foo: T) {\n    println!(\"{:?}\", foo);\n}\n\nfn main() {\n    // Calling the method is still fine, as i32 implements Debug.\n    some_func(5i32);\n\n    // This would fail to compile now:\n    // struct WithoutDebug;\n    // some_func(WithoutDebug);\n}\n```\n\nRust only looks at the signature of the called function, as such it must\nalready specify all requirements that will be used for every type parameter.\n"},"level":"error","spans":[{"file_name":"json_error_demo.rs","byte_start":50,"byte_end":51,"line_start":4,"line_end":4,"column_start":7,"column_end":8,"is_primary":true,"text":[{"text":"    a + b","highlight_start":7,"highlight_end":8}],"label":"no implementation for `{integer} + &str`","suggested_replacement":null,"suggestion_applicability":null,"expansion":null}],"children":[{"message":"the trait `std::ops::Add<&str>` is not implemented for `{integer}`","code":null,"level":"help","spans":[],"children":[],"rendered":null}],"rendered":"error[E0277]: cannot add `&str` to `{integer}`\n --> json_error_demo.rs:4:7\n  |\n4 |     a + b\n  |       ^ no implementation for `{integer} + &str`\n  |\n  = help: the trait `std::ops::Add<&str>` is not implemented for `{integer}`\n\n"}
+```
+            """#;
+        let book = MDBook::init()
+            .config(Config::pdf())
+            .chapter(Chapter::new("", content, "chapter.md"))
+            .build();
+        insta::assert_display_snapshot!(book, @r###"
+        ├─ log output
+        │  INFO mdbook::book: Running the pandoc backend    
+        │  INFO mdbook_pandoc::pandoc::renderer: Wrote output to book/pdf/book.pdf    
+        ├─ pdf/book.pdf
+        │ <INVALID UTF8>
+        "###);
+    }
+
+    #[test]
     fn mdbook_rust_code_block_attributes() {
         let book = MDBook::init()
             .config(Config::latex())

--- a/src/pandoc/renderer.rs
+++ b/src/pandoc/renderer.rs
@@ -122,6 +122,18 @@ impl Renderer {
         let mut additional_variables = vec![];
         match &mut ctx.output {
             OutputFormat::Latex { packages } => {
+                // Enable line breaking in code blocks
+                additional_variables.push((
+                    "header-includes",
+                    r"
+\IfFileExists{fvextra.sty}{% use fvextra if available to break long lines in code blocks
+  \usepackage{fvextra}
+  \fvset{breaklines}
+}{}
+"
+                    .into(),
+                ));
+
                 // https://www.overleaf.com/learn/latex/Lists#Lists_for_lawyers:_nesting_lists_to_an_arbitrary_depth
                 const LATEX_DEFAULT_LIST_DEPTH_LIMIT: usize = 4;
 

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -11,6 +11,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use aho_corasick::AhoCorasick;
 use anyhow::{anyhow, Context as _};
 use mdbook::{
     book::{BookItems, Chapter},
@@ -614,7 +615,7 @@ impl<'book, 'preprocessor> PreprocessChapter<'book, 'preprocessor> {
 
         while let Some((event, range)) = self.parser.next() {
             let event = match event {
-                Event::Start(tag) => {
+                Event::Start(tag) => 'current_event: {
                     let tag = match tag {
                         Tag::List(start_number) => {
                             self.preprocessor.ctx.cur_list_depth += 1;
@@ -687,7 +688,76 @@ impl<'book, 'preprocessor> PreprocessChapter<'book, 'preprocessor> {
                                 Cow::Borrowed(_) => info_string,
                                 Cow::Owned(info_string) => info_string.into(),
                             };
-                            Tag::CodeBlock(CodeBlockKind::Fenced(info_string))
+
+                            let code_block = Tag::CodeBlock(CodeBlockKind::Fenced(info_string));
+
+                            if let OutputFormat::Latex { .. } = self.preprocessor.ctx.output {
+                                const CODE_BLOCK_LINE_LENGTH_LIMIT: usize = 1000;
+
+                                let mut texts = vec![];
+                                let mut overly_long_line = false;
+                                for (event, _) in &mut self.parser {
+                                    match event {
+                                        Event::Text(text) => {
+                                            if text.lines().any(|line| {
+                                                line.len() > CODE_BLOCK_LINE_LENGTH_LIMIT
+                                            }) {
+                                                overly_long_line = true;
+                                            }
+                                            texts.push(text)
+                                        }
+                                        Event::End(Tag::CodeBlock(_)) => break,
+                                        event => {
+                                            co.yield_(Event::Start(code_block)).await;
+                                            for text in texts {
+                                                co.yield_(Event::Text(text)).await;
+                                            }
+                                            break 'current_event event;
+                                        }
+                                    }
+                                }
+
+                                if overly_long_line {
+                                    (self.preprocessor.ctx.pandoc)
+                                        .enable_extension(pandoc::Extension::RawAttribute);
+                                    let raw_latex =
+                                        || Tag::CodeBlock(CodeBlockKind::Fenced("{=latex}".into()));
+                                    let lines = {
+                                        let patterns = &[r"\", "{", "}", "$", "_", "^", "&", "]"];
+                                        let replace_with = &[
+                                            r"\textbackslash{}",
+                                            r"\{",
+                                            r"\}",
+                                            r"\$",
+                                            r"\_",
+                                            r"\^",
+                                            r"\&",
+                                            r"{{]}}",
+                                        ];
+                                        let ac = AhoCorasick::new(patterns).unwrap();
+                                        texts.iter().flat_map(|text| text.lines()).map(
+                                            move |text| {
+                                                let text = ac.replace_all(text, replace_with);
+                                                Event::Text(format!(r"\texttt{{{text}}}\\").into())
+                                            },
+                                        )
+                                    };
+                                    for event in iter::once(Event::Start(raw_latex())).chain(lines)
+                                    {
+                                        co.yield_(event).await
+                                    }
+                                    break 'current_event Event::End(raw_latex());
+                                } else {
+                                    for event in iter::once(Event::Start(code_block.clone()))
+                                        .chain(texts.into_iter().map(Event::Text))
+                                    {
+                                        co.yield_(event).await;
+                                    }
+                                    break 'current_event Event::End(code_block);
+                                }
+                            }
+
+                            code_block
                         }
                         tag => tag,
                     };

--- a/src/snapshots/mdbook_pandoc__tests__cargo_book.snap
+++ b/src/snapshots/mdbook_pandoc__tests__cargo_book.snap
@@ -170,10 +170,10 @@ DEBUG mdbook_pandoc::preprocess: Unable to resolve relative path '../../referenc
 DEBUG mdbook_pandoc::pandoc::renderer: Running pandoc    
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__commands__cargomd__option-cargo---offline'
-  on page 290 undefined on input line 19567.
+  on page 290 undefined on input line 19579.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__commands__cargo-buildmd__option-cargo-build---keep-going'
-  on page 294 undefined on input line 19805.
+  on page 294 undefined on input line 19817.
 [WARNING] [makePDF] LaTeX Warning: There were undefined references.
  INFO mdbook_pandoc::pandoc::renderer: Wrote output to book/pdf/book.pdf    
 

--- a/src/snapshots/mdbook_pandoc__tests__cargo_book.snap
+++ b/src/snapshots/mdbook_pandoc__tests__cargo_book.snap
@@ -170,10 +170,10 @@ DEBUG mdbook_pandoc::preprocess: Unable to resolve relative path '../../referenc
 DEBUG mdbook_pandoc::pandoc::renderer: Running pandoc    
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__commands__cargomd__option-cargo---offline'
-  on page 290 undefined on input line 19579.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__commands__cargo-buildmd__option-cargo-build---keep-going'
-  on page 294 undefined on input line 19817.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: There were undefined references.
  INFO mdbook_pandoc::pandoc::renderer: Wrote output to book/pdf/book.pdf    
 

--- a/src/snapshots/mdbook_pandoc__tests__cargo_book.snap
+++ b/src/snapshots/mdbook_pandoc__tests__cargo_book.snap
@@ -170,10 +170,10 @@ DEBUG mdbook_pandoc::preprocess: Unable to resolve relative path '../../referenc
 DEBUG mdbook_pandoc::pandoc::renderer: Running pandoc    
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__commands__cargomd__option-cargo---offline'
-  on page 281 undefined on input line 19562.
+  on page 290 undefined on input line 19567.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__commands__cargo-buildmd__option-cargo-build---keep-going'
-  on page 285 undefined on input line 19800.
+  on page 294 undefined on input line 19805.
 [WARNING] [makePDF] LaTeX Warning: There were undefined references.
  INFO mdbook_pandoc::pandoc::renderer: Wrote output to book/pdf/book.pdf    
 

--- a/src/snapshots/mdbook_pandoc__tests__rust_book.snap
+++ b/src/snapshots/mdbook_pandoc__tests__rust_book.snap
@@ -39,16 +39,16 @@ expression: logs
  WARN mdbook_pandoc: Unable to resolve one or more relative links within the book, consider setting the `hosted-html` option in `[output.pandoc]`    
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__ch15-02-derefmd__following-the-pointer-to-the-value-with-the-dereference-operator'
-  on page 195 undefined on input line 10897.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__ch06-02-matchmd__the-match-control-flow-operator'
-  on page 612 undefined on input line 33749.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__ch13-01-closuresmd__moving-captured-values-out-of-the-closure-and-the-fn-traits'
-  on page 655 undefined on input line 36119.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__ch04-01-what-is-ownershipmd__ways-variables-and-data-interact-clone'
-  on page 709 undefined on input line 38984.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: There were undefined references.
 [WARNING] Missing character: There is no 🚨 (U+1F6A8) (U+1F6A8) in font NotoSerif/B:mode=node;scri
 [WARNING] Missing character: There is no 👍 (U+1F44D) (U+1F44D) in font NotoSansMono:mode=node;scr

--- a/src/snapshots/mdbook_pandoc__tests__rust_book.snap
+++ b/src/snapshots/mdbook_pandoc__tests__rust_book.snap
@@ -39,16 +39,16 @@ expression: logs
  WARN mdbook_pandoc: Unable to resolve one or more relative links within the book, consider setting the `hosted-html` option in `[output.pandoc]`    
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__ch15-02-derefmd__following-the-pointer-to-the-value-with-the-dereference-operator'
-  on page 188 undefined on input line 10892.
+  on page 195 undefined on input line 10897.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__ch06-02-matchmd__the-match-control-flow-operator'
-  on page 589 undefined on input line 33744.
+  on page 612 undefined on input line 33749.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__ch13-01-closuresmd__moving-captured-values-out-of-the-closure-and-the-fn-traits'
-  on page 630 undefined on input line 36114.
+  on page 655 undefined on input line 36119.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__ch04-01-what-is-ownershipmd__ways-variables-and-data-interact-clone'
-  on page 682 undefined on input line 38979.
+  on page 709 undefined on input line 38984.
 [WARNING] [makePDF] LaTeX Warning: There were undefined references.
 [WARNING] Missing character: There is no 🚨 (U+1F6A8) (U+1F6A8) in font NotoSerif/B:mode=node;scri
 [WARNING] Missing character: There is no 👍 (U+1F44D) (U+1F44D) in font NotoSansMono:mode=node;scr

--- a/src/snapshots/mdbook_pandoc__tests__rust_embedded.snap
+++ b/src/snapshots/mdbook_pandoc__tests__rust_embedded.snap
@@ -5,28 +5,28 @@ expression: logs
  INFO mdbook::book: Running the pandoc backend    
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__design-patterns__hal__namingmd__c-crate-name'
-  on page 99 undefined on input line 5829.
+  on page 103 undefined on input line 5834.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__design-patterns__hal__interoperabilitymd__c-free'
-  on page 99 undefined on input line 5839.
+  on page 103 undefined on input line 5844.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__design-patterns__hal__interoperabilitymd__c-reexport-pac'
-  on page 99 undefined on input line 5842.
+  on page 103 undefined on input line 5847.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__design-patterns__hal__interoperabilitymd__c-hal-traits'
-  on page 99 undefined on input line 5845.
+  on page 103 undefined on input line 5850.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__design-patterns__hal__predictabilitymd__c-ctor'
-  on page 99 undefined on input line 5855.
+  on page 103 undefined on input line 5860.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__design-patterns__hal__gpiomd__c-zst-pin' on
-  page 99 undefined on input line 5865.
+  page 103 undefined on input line 5870.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__design-patterns__hal__gpiomd__c-erased-pin'
-  on page 100 undefined on input line 5868.
+  on page 104 undefined on input line 5873.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__design-patterns__hal__gpiomd__c-pin-state'
-  on page 100 undefined on input line 5871.
+  on page 104 undefined on input line 5876.
 [WARNING] [makePDF] LaTeX Warning: There were undefined references.
 [WARNING] Missing character: There is no 🦀 (U+1F980) (U+1F980) in font NotoSerif:mode=node;script
 [WARNING] Missing character: There is no ✓ (U+2713) (U+2713) in font NotoSerif:mode=node;script=l

--- a/src/snapshots/mdbook_pandoc__tests__rust_embedded.snap
+++ b/src/snapshots/mdbook_pandoc__tests__rust_embedded.snap
@@ -5,28 +5,28 @@ expression: logs
  INFO mdbook::book: Running the pandoc backend    
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__design-patterns__hal__namingmd__c-crate-name'
-  on page 103 undefined on input line 5834.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__design-patterns__hal__interoperabilitymd__c-free'
-  on page 103 undefined on input line 5844.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__design-patterns__hal__interoperabilitymd__c-reexport-pac'
-  on page 103 undefined on input line 5847.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__design-patterns__hal__interoperabilitymd__c-hal-traits'
-  on page 103 undefined on input line 5850.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__design-patterns__hal__predictabilitymd__c-ctor'
-  on page 103 undefined on input line 5860.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__design-patterns__hal__gpiomd__c-zst-pin' on
-  page 103 undefined on input line 5870.
+  $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__design-patterns__hal__gpiomd__c-erased-pin'
-  on page 104 undefined on input line 5873.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__design-patterns__hal__gpiomd__c-pin-state'
-  on page 104 undefined on input line 5876.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: There were undefined references.
 [WARNING] Missing character: There is no 🦀 (U+1F980) (U+1F980) in font NotoSerif:mode=node;script
 [WARNING] Missing character: There is no ✓ (U+2713) (U+2713) in font NotoSerif:mode=node;script=l

--- a/src/snapshots/mdbook_pandoc__tests__rust_reference.snap
+++ b/src/snapshots/mdbook_pandoc__tests__rust_reference.snap
@@ -198,46 +198,46 @@ expression: logs
  WARN mdbook_pandoc: Unable to resolve one or more relative links within the book, consider setting the `hosted-html` option in `[output.pandoc]`    
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__type-layoutmd__the-default-representation'
-  on page 89 undefined on input line 5618.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__items__enumerationsmd__unit-only-enum' on
-  page 90 undefined on input line 5637.
+  $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__items__enumerationsmd__unit-only-enum' on
-  page 91 undefined on input line 5733.
+  $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__items__enumerationsmd__field-less-enum' on
-  page 91 undefined on input line 5754.
+  $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__statementsmd__let-else-restriction' on page
-  171 undefined on input line 10945.
+  171 undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__items__enumerationsmd__unit-only-enum' on
-  page 198 undefined on input line 12980.
+  $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__items__enumerationsmd__field-less-enum' on
-  page 198 undefined on input line 12983.
+  $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__type-layoutmd__the-rust-representation' on
-  page 277 undefined on input line 18366.
+  $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__type-layoutmd__the-rust-representation' on
-  page 277 undefined on input line 18397.
+  $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__items__enumerationsmd__field-less-enum' on
-  page 281 undefined on input line 18628.
+  $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__items__enumerationsmd__field-less-enum' on
-  page 281 undefined on input line 18641.
+  $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__items__enumerationsmd__field-less-enum' on
-  page 281 undefined on input line 18646.
+  $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__items__enumerationsmd__field-less-enum' on
-  page 283 undefined on input line 18754.
+  $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__type-layoutmd__the-rust-representation' on
-  page 286 undefined on input line 18933.
+  $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: There were undefined references.
 [WARNING] Missing character: There is no 東 (U+6771) (U+6771) in font NotoSansMono:mode=node;scrip
 [WARNING] Missing character: There is no 京 (U+4EAC) (U+4EAC) in font NotoSansMono:mode=node;scrip

--- a/src/snapshots/mdbook_pandoc__tests__rust_reference.snap
+++ b/src/snapshots/mdbook_pandoc__tests__rust_reference.snap
@@ -198,46 +198,46 @@ expression: logs
  WARN mdbook_pandoc: Unable to resolve one or more relative links within the book, consider setting the `hosted-html` option in `[output.pandoc]`    
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__type-layoutmd__the-default-representation'
-  on page 88 undefined on input line 5613.
+  on page 89 undefined on input line 5618.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__items__enumerationsmd__unit-only-enum' on
-  page 88 undefined on input line 5632.
+  page 90 undefined on input line 5637.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__items__enumerationsmd__unit-only-enum' on
-  page 89 undefined on input line 5728.
+  page 91 undefined on input line 5733.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__items__enumerationsmd__field-less-enum' on
-  page 89 undefined on input line 5749.
+  page 91 undefined on input line 5754.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__statementsmd__let-else-restriction' on page
-  167 undefined on input line 10940.
+  171 undefined on input line 10945.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__items__enumerationsmd__unit-only-enum' on
-  page 194 undefined on input line 12975.
+  page 198 undefined on input line 12980.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__items__enumerationsmd__field-less-enum' on
-  page 194 undefined on input line 12978.
+  page 198 undefined on input line 12983.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__type-layoutmd__the-rust-representation' on
-  page 271 undefined on input line 18361.
+  page 277 undefined on input line 18366.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__type-layoutmd__the-rust-representation' on
-  page 271 undefined on input line 18392.
+  page 277 undefined on input line 18397.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__items__enumerationsmd__field-less-enum' on
-  page 275 undefined on input line 18623.
+  page 281 undefined on input line 18628.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__items__enumerationsmd__field-less-enum' on
-  page 275 undefined on input line 18636.
+  page 281 undefined on input line 18641.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__items__enumerationsmd__field-less-enum' on
-  page 275 undefined on input line 18641.
+  page 281 undefined on input line 18646.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__items__enumerationsmd__field-less-enum' on
-  page 277 undefined on input line 18749.
+  page 283 undefined on input line 18754.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__type-layoutmd__the-rust-representation' on
-  page 280 undefined on input line 18928.
+  page 286 undefined on input line 18933.
 [WARNING] [makePDF] LaTeX Warning: There were undefined references.
 [WARNING] Missing character: There is no 東 (U+6771) (U+6771) in font NotoSansMono:mode=node;scrip
 [WARNING] Missing character: There is no 京 (U+4EAC) (U+4EAC) in font NotoSansMono:mode=node;scrip

--- a/src/snapshots/mdbook_pandoc__tests__rustc_dev_guide.snap
+++ b/src/snapshots/mdbook_pandoc__tests__rustc_dev_guide.snap
@@ -27,208 +27,208 @@ expression: logs
  WARN mdbook_pandoc: Unable to resolve one or more relative links within the book, consider setting the `hosted-html` option in `[output.pandoc]`    
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__ice' on page
-  26 undefined on input line 1356.
+  26 undefined on input line 1360.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__conventionsmd__formatting' on page
-  42 undefined on input line 2383.
+  42 undefined on input line 2393.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__tests__addingmd__explanatory_comment'
-  on page 54 undefined on input line 3245.
+  on page 54 undefined on input line 3257.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__building__how-to-build-and-runmd__toolchain'
-  on page 106 undefined on input line 6619.
+  on page 106 undefined on input line 6655.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__gitmd__conflicts' on page 135
-  undefined on input line 8304.
+  `book__pandoc__pdf__src__gitmd__conflicts' on page 136
+  undefined on input line 8348.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__walkthroughmd__impl' on page 148
-  undefined on input line 8921.
+  `book__pandoc__pdf__src__walkthroughmd__impl' on page 149
+  undefined on input line 8987.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__conventionsmd__formatting' on page
-  166 undefined on input line 9919.
+  167 undefined on input line 9985.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__conventionsmd__cc' on page 166
-  undefined on input line 9921.
+  `book__pandoc__pdf__src__conventionsmd__cc' on page 167
+  undefined on input line 9987.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__conventionsmd__cio' on page 166
-  undefined on input line 9923.
+  `book__pandoc__pdf__src__conventionsmd__cio' on page 167
+  undefined on input line 9989.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__conventionsmd__er' on page 166
-  undefined on input line 9925.
-[WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__notification-groups__aboutmd__join'
-  on page 189 undefined on input line 10891.
+  `book__pandoc__pdf__src__conventionsmd__er' on page 167
+  undefined on input line 9991.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__notification-groups__aboutmd__join'
-  on page 189 undefined on input line 10896.
+  on page 191 undefined on input line 10971.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__notification-groups__aboutmd__join'
+  on page 191 undefined on input line 10976.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__intrinsic' on
-  page 223 undefined on input line 12864.
+  page 225 undefined on input line 12944.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__queries__incremental-compilationmd__dag'
-  on page 241 undefined on input line 13988.
+  on page 244 undefined on input line 14072.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__querymd__adding-a-new-kind-of-query'
-  on page 252 undefined on input line 14576.
+  on page 255 undefined on input line 14660.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__generic_argumentsmd__GenericArgs'
-  on page 264 undefined on input line 15193.
+  on page 267 undefined on input line 15277.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__cfg' on
-  page 331 undefined on input line 19001.
+  page 334 undefined on input line 19087.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__cfg' on
-  page 331 undefined on input line 19029.
+  page 334 undefined on input line 19115.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__mir__indexmd__promoted' on page 335
-  undefined on input line 19264.
-[WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__appendix__glossarymd__newtype' on
-  page 335 undefined on input line 19277.
+  `book__pandoc__pdf__src__mir__indexmd__promoted' on page 338
+  undefined on input line 19350.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__newtype' on
-  page 335 undefined on input line 19287.
+  page 338 undefined on input line 19363.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__newtype' on
-  page 335 undefined on input line 19307.
+  page 338 undefined on input line 19373.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__glossarymd__newtype' on
+  page 338 undefined on input line 19393.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__placeholder'
-  on page 399 undefined on input line 23020.
+  on page 402 undefined on input line 23106.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__type-inferencemd__vars' on page 416
-  undefined on input line 24272.
+  `book__pandoc__pdf__src__type-inferencemd__vars' on page 419
+  undefined on input line 24358.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__free-vs-bound'
-  on page 417 undefined on input line 24310.
+  on page 420 undefined on input line 24396.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__traits__canonical-queriesmd__query-response'
-  on page 418 undefined on input line 24390.
+  on page 421 undefined on input line 24476.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__traits__canonical-queriesmd__query-response'
-  on page 418 undefined on input line 24431.
+  on page 421 undefined on input line 24517.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__variancemd__addendum' on page 442
-  undefined on input line 26061.
+  `book__pandoc__pdf__src__variancemd__addendum' on page 445
+  undefined on input line 26147.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__opaque-types-impl-trait-inferencemd__Within-the-type_of-query'
-  on page 450 undefined on input line 26607.
+  on page 453 undefined on input line 26693.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__region' on
-  page 484 undefined on input line 28361.
+  page 487 undefined on input line 28449.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__inf-var' on
-  page 484 undefined on input line 28364.
+  page 487 undefined on input line 28452.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__dataflow'
-  on page 484 undefined on input line 28368.
+  on page 487 undefined on input line 28456.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__free-vs-bound'
-  on page 492 undefined on input line 28960.
+  on page 495 undefined on input line 29048.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__point' on
-  page 497 undefined on input line 29362.
+  page 500 undefined on input line 29450.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__borrow_check__region_inference__member_constraintsmd__collecting'
-  on page 505 undefined on input line 29927.
+  on page 508 undefined on input line 30015.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__quantified'
-  on page 507 undefined on input line 30031.
+  on page 510 undefined on input line 30119.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__variance'
-  on page 507 undefined on input line 30053.
+  on page 510 undefined on input line 30141.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__free-vs-bound'
-  on page 507 undefined on input line 30103.
+  on page 510 undefined on input line 30191.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__diagnosticsmd__future-incompatible'
-  on page 523 undefined on input line 31056.
+  on page 526 undefined on input line 31146.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__mono' on page
-  565 undefined on input line 33642.
+  568 undefined on input line 33736.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__def-id' on
-  page 565 undefined on input line 33656.
+  page 568 undefined on input line 33750.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__codegen-unit'
-  on page 578 undefined on input line 34372.
+  on page 581 undefined on input line 34466.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__cfg' on
-  page 637 undefined on input line 37723.
+  page 641 undefined on input line 37825.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__free-vs-bound'
-  on page 643 undefined on input line 38090.
+  on page 647 undefined on input line 38192.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__free-vs-bound'
-  on page 643 undefined on input line 38100.
+  on page 647 undefined on input line 38202.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__cfg' on
-  page 643 undefined on input line 38114.
+  page 647 undefined on input line 38216.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__TyCtxt' on
-  page 643 undefined on input line 38122.
+  page 647 undefined on input line 38224.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__cx' on page
-  643 undefined on input line 38123.
+  647 undefined on input line 38225.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__tcx' on page
-  643 undefined on input line 38124.
+  647 undefined on input line 38226.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__dataflow'
-  on page 643 undefined on input line 38132.
+  on page 647 undefined on input line 38234.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__what-is-a-debruijn-index'
-  on page 643 undefined on input line 38137.
+  on page 647 undefined on input line 38239.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__variant-idx'
-  on page 643 undefined on input line 38148.
+  on page 647 undefined on input line 38250.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__tag' on page
-  643 undefined on input line 38150.
+  647 undefined on input line 38252.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__free-vs-bound'
-  on page 643 undefined on input line 38182.
+  on page 647 undefined on input line 38284.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__tag' on page
-  643 undefined on input line 38297.
+  647 undefined on input line 38399.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__traits__goals-and-clausesmd__trait-ref'
-  on page 643 undefined on input line 38327.
+  on page 647 undefined on input line 38429.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__mir__indexmd__promoted' on page 643
-  undefined on input line 38330.
+  `book__pandoc__pdf__src__mir__indexmd__promoted' on page 647
+  undefined on input line 38432.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__quantified'
-  on page 643 undefined on input line 38338.
+  on page 647 undefined on input line 38440.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__discriminant'
-  on page 643 undefined on input line 38393.
+  on page 647 undefined on input line 38495.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__niche' on
-  page 643 undefined on input line 38396.
+  page 647 undefined on input line 38498.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__traits__goals-and-clausesmd__trait-ref'
-  on page 643 undefined on input line 38420.
+  on page 647 undefined on input line 38522.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__tcx' on page
-  643 undefined on input line 38428.
+  647 undefined on input line 38530.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__variance'
-  on page 643 undefined on input line 38447.
+  on page 647 undefined on input line 38549.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__discriminant'
-  on page 643 undefined on input line 38453.
+  on page 647 undefined on input line 38555.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__hirmd__hir-id' on page 702
-  undefined on input line 38501.
+  `book__pandoc__pdf__src__hirmd__hir-id' on page 706
+  undefined on input line 38603.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__hirmd__hir-id' on page 702
-  undefined on input line 38517.
+  `book__pandoc__pdf__src__hirmd__hir-id' on page 706
+  undefined on input line 38619.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__hirmd__hir-id' on page 702
-  undefined on input line 38529.
+  `book__pandoc__pdf__src__hirmd__hir-id' on page 706
+  undefined on input line 38631.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__hirmd__hir-id' on page 702
-  undefined on input line 38534.
+  `book__pandoc__pdf__src__hirmd__hir-id' on page 706
+  undefined on input line 38636.
 [WARNING] [makePDF] LaTeX Warning: There were undefined references.
 [WARNING] Missing character: There is no 🔑 (U+1F511) (U+1F511) in font NotoSerif:mode=node;script
 [WARNING] Missing character: There is no ✅ (U+2705) (U+2705) in font NotoSerif:mode=node;script=l

--- a/src/snapshots/mdbook_pandoc__tests__rustc_dev_guide.snap
+++ b/src/snapshots/mdbook_pandoc__tests__rustc_dev_guide.snap
@@ -27,208 +27,208 @@ expression: logs
  WARN mdbook_pandoc: Unable to resolve one or more relative links within the book, consider setting the `hosted-html` option in `[output.pandoc]`    
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__ice' on page
-  26 undefined on input line 1351.
+  26 undefined on input line 1356.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__conventionsmd__formatting' on page
-  41 undefined on input line 2378.
+  42 undefined on input line 2383.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__tests__addingmd__explanatory_comment'
-  on page 53 undefined on input line 3240.
+  on page 54 undefined on input line 3245.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__building__how-to-build-and-runmd__toolchain'
-  on page 104 undefined on input line 6614.
+  on page 106 undefined on input line 6619.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__gitmd__conflicts' on page 133
-  undefined on input line 8299.
+  `book__pandoc__pdf__src__gitmd__conflicts' on page 135
+  undefined on input line 8304.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__walkthroughmd__impl' on page 146
-  undefined on input line 8916.
+  `book__pandoc__pdf__src__walkthroughmd__impl' on page 148
+  undefined on input line 8921.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__conventionsmd__formatting' on page
-  164 undefined on input line 9914.
+  166 undefined on input line 9919.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__conventionsmd__cc' on page 164
-  undefined on input line 9916.
+  `book__pandoc__pdf__src__conventionsmd__cc' on page 166
+  undefined on input line 9921.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__conventionsmd__cio' on page 164
-  undefined on input line 9918.
+  `book__pandoc__pdf__src__conventionsmd__cio' on page 166
+  undefined on input line 9923.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__conventionsmd__er' on page 164
-  undefined on input line 9920.
-[WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__notification-groups__aboutmd__join'
-  on page 187 undefined on input line 10886.
+  `book__pandoc__pdf__src__conventionsmd__er' on page 166
+  undefined on input line 9925.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__notification-groups__aboutmd__join'
-  on page 187 undefined on input line 10891.
+  on page 189 undefined on input line 10891.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__notification-groups__aboutmd__join'
+  on page 189 undefined on input line 10896.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__intrinsic' on
-  page 220 undefined on input line 12859.
+  page 223 undefined on input line 12864.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__queries__incremental-compilationmd__dag'
-  on page 238 undefined on input line 13983.
+  on page 241 undefined on input line 13988.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__querymd__adding-a-new-kind-of-query'
-  on page 248 undefined on input line 14571.
+  on page 252 undefined on input line 14576.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__generic_argumentsmd__GenericArgs'
-  on page 259 undefined on input line 15188.
+  on page 264 undefined on input line 15193.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__cfg' on
-  page 324 undefined on input line 18996.
+  page 331 undefined on input line 19001.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__cfg' on
-  page 324 undefined on input line 19024.
+  page 331 undefined on input line 19029.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__mir__indexmd__promoted' on page 328
-  undefined on input line 19259.
-[WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__appendix__glossarymd__newtype' on
-  page 328 undefined on input line 19272.
+  `book__pandoc__pdf__src__mir__indexmd__promoted' on page 335
+  undefined on input line 19264.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__newtype' on
-  page 328 undefined on input line 19282.
+  page 335 undefined on input line 19277.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__newtype' on
-  page 328 undefined on input line 19302.
+  page 335 undefined on input line 19287.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__glossarymd__newtype' on
+  page 335 undefined on input line 19307.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__placeholder'
-  on page 392 undefined on input line 23015.
+  on page 399 undefined on input line 23020.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__type-inferencemd__vars' on page 408
-  undefined on input line 24267.
+  `book__pandoc__pdf__src__type-inferencemd__vars' on page 416
+  undefined on input line 24272.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__free-vs-bound'
-  on page 409 undefined on input line 24305.
+  on page 417 undefined on input line 24310.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__traits__canonical-queriesmd__query-response'
-  on page 410 undefined on input line 24385.
+  on page 418 undefined on input line 24390.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__traits__canonical-queriesmd__query-response'
-  on page 410 undefined on input line 24426.
+  on page 418 undefined on input line 24431.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__variancemd__addendum' on page 434
-  undefined on input line 26056.
+  `book__pandoc__pdf__src__variancemd__addendum' on page 442
+  undefined on input line 26061.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__opaque-types-impl-trait-inferencemd__Within-the-type_of-query'
-  on page 442 undefined on input line 26602.
+  on page 450 undefined on input line 26607.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__region' on
-  page 475 undefined on input line 28356.
+  page 484 undefined on input line 28361.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__inf-var' on
-  page 475 undefined on input line 28359.
+  page 484 undefined on input line 28364.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__dataflow'
-  on page 475 undefined on input line 28363.
+  on page 484 undefined on input line 28368.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__free-vs-bound'
-  on page 483 undefined on input line 28955.
+  on page 492 undefined on input line 28960.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__point' on
-  page 488 undefined on input line 29357.
+  page 497 undefined on input line 29362.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__borrow_check__region_inference__member_constraintsmd__collecting'
-  on page 496 undefined on input line 29922.
+  on page 505 undefined on input line 29927.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__quantified'
-  on page 498 undefined on input line 30026.
+  on page 507 undefined on input line 30031.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__variance'
-  on page 498 undefined on input line 30048.
+  on page 507 undefined on input line 30053.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__free-vs-bound'
-  on page 498 undefined on input line 30098.
+  on page 507 undefined on input line 30103.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__diagnosticsmd__future-incompatible'
-  on page 513 undefined on input line 31051.
+  on page 523 undefined on input line 31056.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__mono' on page
-  552 undefined on input line 33644.
+  565 undefined on input line 33642.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__def-id' on
-  page 552 undefined on input line 33658.
+  page 565 undefined on input line 33656.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__codegen-unit'
-  on page 565 undefined on input line 34374.
+  on page 578 undefined on input line 34372.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__cfg' on
-  page 622 undefined on input line 37725.
+  page 637 undefined on input line 37723.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__free-vs-bound'
-  on page 628 undefined on input line 38092.
+  on page 643 undefined on input line 38090.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__free-vs-bound'
-  on page 628 undefined on input line 38102.
+  on page 643 undefined on input line 38100.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__cfg' on
-  page 628 undefined on input line 38116.
+  page 643 undefined on input line 38114.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__TyCtxt' on
-  page 628 undefined on input line 38124.
+  page 643 undefined on input line 38122.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__cx' on page
-  628 undefined on input line 38125.
+  643 undefined on input line 38123.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__tcx' on page
-  628 undefined on input line 38126.
+  643 undefined on input line 38124.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__dataflow'
-  on page 628 undefined on input line 38134.
+  on page 643 undefined on input line 38132.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__what-is-a-debruijn-index'
-  on page 628 undefined on input line 38139.
+  on page 643 undefined on input line 38137.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__variant-idx'
-  on page 628 undefined on input line 38150.
+  on page 643 undefined on input line 38148.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__tag' on page
-  628 undefined on input line 38152.
+  643 undefined on input line 38150.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__free-vs-bound'
-  on page 628 undefined on input line 38184.
+  on page 643 undefined on input line 38182.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__tag' on page
-  628 undefined on input line 38299.
+  643 undefined on input line 38297.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__traits__goals-and-clausesmd__trait-ref'
-  on page 628 undefined on input line 38329.
+  on page 643 undefined on input line 38327.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__mir__indexmd__promoted' on page 628
-  undefined on input line 38332.
+  `book__pandoc__pdf__src__mir__indexmd__promoted' on page 643
+  undefined on input line 38330.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__quantified'
-  on page 628 undefined on input line 38340.
+  on page 643 undefined on input line 38338.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__discriminant'
-  on page 628 undefined on input line 38395.
+  on page 643 undefined on input line 38393.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__niche' on
-  page 628 undefined on input line 38398.
+  page 643 undefined on input line 38396.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__traits__goals-and-clausesmd__trait-ref'
-  on page 628 undefined on input line 38422.
+  on page 643 undefined on input line 38420.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__tcx' on page
-  628 undefined on input line 38430.
+  643 undefined on input line 38428.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__variance'
-  on page 628 undefined on input line 38449.
+  on page 643 undefined on input line 38447.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__discriminant'
-  on page 628 undefined on input line 38455.
+  on page 643 undefined on input line 38453.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__hirmd__hir-id' on page 687
-  undefined on input line 38503.
+  `book__pandoc__pdf__src__hirmd__hir-id' on page 702
+  undefined on input line 38501.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__hirmd__hir-id' on page 687
-  undefined on input line 38519.
+  `book__pandoc__pdf__src__hirmd__hir-id' on page 702
+  undefined on input line 38517.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__hirmd__hir-id' on page 687
-  undefined on input line 38531.
+  `book__pandoc__pdf__src__hirmd__hir-id' on page 702
+  undefined on input line 38529.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__hirmd__hir-id' on page 687
-  undefined on input line 38536.
+  `book__pandoc__pdf__src__hirmd__hir-id' on page 702
+  undefined on input line 38534.
 [WARNING] [makePDF] LaTeX Warning: There were undefined references.
 [WARNING] Missing character: There is no 🔑 (U+1F511) (U+1F511) in font NotoSerif:mode=node;script
 [WARNING] Missing character: There is no ✅ (U+2705) (U+2705) in font NotoSerif:mode=node;script=l

--- a/src/snapshots/mdbook_pandoc__tests__rustc_dev_guide.snap
+++ b/src/snapshots/mdbook_pandoc__tests__rustc_dev_guide.snap
@@ -27,208 +27,208 @@ expression: logs
  WARN mdbook_pandoc: Unable to resolve one or more relative links within the book, consider setting the `hosted-html` option in `[output.pandoc]`    
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__ice' on page
-  26 undefined on input line 1360.
+  26 undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__conventionsmd__formatting' on page
-  42 undefined on input line 2393.
+  42 undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__tests__addingmd__explanatory_comment'
-  on page 54 undefined on input line 3257.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__building__how-to-build-and-runmd__toolchain'
-  on page 106 undefined on input line 6655.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__gitmd__conflicts' on page 136
-  undefined on input line 8348.
+  `book__pandoc__pdf__src__gitmd__conflicts' on $PAGE
+  undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__walkthroughmd__impl' on page 149
-  undefined on input line 8987.
+  `book__pandoc__pdf__src__walkthroughmd__impl' on $PAGE
+  undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__conventionsmd__formatting' on page
-  167 undefined on input line 9985.
+  167 undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__conventionsmd__cc' on page 167
-  undefined on input line 9987.
+  `book__pandoc__pdf__src__conventionsmd__cc' on $PAGE
+  undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__conventionsmd__cio' on page 167
-  undefined on input line 9989.
+  `book__pandoc__pdf__src__conventionsmd__cio' on $PAGE
+  undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__conventionsmd__er' on page 167
-  undefined on input line 9991.
-[WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__notification-groups__aboutmd__join'
-  on page 191 undefined on input line 10971.
+  `book__pandoc__pdf__src__conventionsmd__er' on $PAGE
+  undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__notification-groups__aboutmd__join'
-  on page 191 undefined on input line 10976.
+  on $PAGE undefined on input $LINE.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__notification-groups__aboutmd__join'
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__intrinsic' on
-  page 225 undefined on input line 12944.
+  $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__queries__incremental-compilationmd__dag'
-  on page 244 undefined on input line 14072.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__querymd__adding-a-new-kind-of-query'
-  on page 255 undefined on input line 14660.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__generic_argumentsmd__GenericArgs'
-  on page 267 undefined on input line 15277.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__cfg' on
-  page 334 undefined on input line 19087.
+  $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__cfg' on
-  page 334 undefined on input line 19115.
+  $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__mir__indexmd__promoted' on page 338
-  undefined on input line 19350.
-[WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__appendix__glossarymd__newtype' on
-  page 338 undefined on input line 19363.
+  `book__pandoc__pdf__src__mir__indexmd__promoted' on $PAGE
+  undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__newtype' on
-  page 338 undefined on input line 19373.
+  $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__newtype' on
-  page 338 undefined on input line 19393.
+  $PAGE undefined on input $LINE.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__glossarymd__newtype' on
+  $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__placeholder'
-  on page 402 undefined on input line 23106.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__type-inferencemd__vars' on page 419
-  undefined on input line 24358.
+  `book__pandoc__pdf__src__type-inferencemd__vars' on $PAGE
+  undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__free-vs-bound'
-  on page 420 undefined on input line 24396.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__traits__canonical-queriesmd__query-response'
-  on page 421 undefined on input line 24476.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__traits__canonical-queriesmd__query-response'
-  on page 421 undefined on input line 24517.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__variancemd__addendum' on page 445
-  undefined on input line 26147.
+  `book__pandoc__pdf__src__variancemd__addendum' on $PAGE
+  undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__opaque-types-impl-trait-inferencemd__Within-the-type_of-query'
-  on page 453 undefined on input line 26693.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__region' on
-  page 487 undefined on input line 28449.
+  $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__inf-var' on
-  page 487 undefined on input line 28452.
+  $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__dataflow'
-  on page 487 undefined on input line 28456.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__free-vs-bound'
-  on page 495 undefined on input line 29048.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__point' on
-  page 500 undefined on input line 29450.
+  $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__borrow_check__region_inference__member_constraintsmd__collecting'
-  on page 508 undefined on input line 30015.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__quantified'
-  on page 510 undefined on input line 30119.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__variance'
-  on page 510 undefined on input line 30141.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__free-vs-bound'
-  on page 510 undefined on input line 30191.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__diagnosticsmd__future-incompatible'
-  on page 526 undefined on input line 31146.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__mono' on page
-  568 undefined on input line 33736.
+  568 undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__def-id' on
-  page 568 undefined on input line 33750.
+  $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__codegen-unit'
-  on page 581 undefined on input line 34466.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__cfg' on
-  page 641 undefined on input line 37825.
+  $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__free-vs-bound'
-  on page 647 undefined on input line 38192.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__free-vs-bound'
-  on page 647 undefined on input line 38202.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__cfg' on
-  page 647 undefined on input line 38216.
+  $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__TyCtxt' on
-  page 647 undefined on input line 38224.
+  $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__cx' on page
-  647 undefined on input line 38225.
+  647 undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__tcx' on page
-  647 undefined on input line 38226.
+  647 undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__dataflow'
-  on page 647 undefined on input line 38234.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__what-is-a-debruijn-index'
-  on page 647 undefined on input line 38239.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__variant-idx'
-  on page 647 undefined on input line 38250.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__tag' on page
-  647 undefined on input line 38252.
+  647 undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__free-vs-bound'
-  on page 647 undefined on input line 38284.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__tag' on page
-  647 undefined on input line 38399.
+  647 undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__traits__goals-and-clausesmd__trait-ref'
-  on page 647 undefined on input line 38429.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__mir__indexmd__promoted' on page 647
-  undefined on input line 38432.
+  `book__pandoc__pdf__src__mir__indexmd__promoted' on $PAGE
+  undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__quantified'
-  on page 647 undefined on input line 38440.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__discriminant'
-  on page 647 undefined on input line 38495.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__niche' on
-  page 647 undefined on input line 38498.
+  $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__traits__goals-and-clausesmd__trait-ref'
-  on page 647 undefined on input line 38522.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__tcx' on page
-  647 undefined on input line 38530.
+  647 undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__variance'
-  on page 647 undefined on input line 38549.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__discriminant'
-  on page 647 undefined on input line 38555.
+  on $PAGE undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__hirmd__hir-id' on page 706
-  undefined on input line 38603.
+  `book__pandoc__pdf__src__hirmd__hir-id' on $PAGE
+  undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__hirmd__hir-id' on page 706
-  undefined on input line 38619.
+  `book__pandoc__pdf__src__hirmd__hir-id' on $PAGE
+  undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__hirmd__hir-id' on page 706
-  undefined on input line 38631.
+  `book__pandoc__pdf__src__hirmd__hir-id' on $PAGE
+  undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__hirmd__hir-id' on page 706
-  undefined on input line 38636.
+  `book__pandoc__pdf__src__hirmd__hir-id' on $PAGE
+  undefined on input $LINE.
 [WARNING] [makePDF] LaTeX Warning: There were undefined references.
 [WARNING] Missing character: There is no 🔑 (U+1F511) (U+1F511) in font NotoSerif:mode=node;script
 [WARNING] Missing character: There is no ✅ (U+2705) (U+2705) in font NotoSerif:mode=node;script=l


### PR DESCRIPTION
Uses the [`fvextra` package](https://mirror.mwt.me/ctan/macros/latex/contrib/fvextra/fvextra.pdf) to enable line wrapping in code blocks in LaTeX books.

TODO:
- [x] ~Really long lines result in errors (see rustc-dev-guide, https://github.com/Wandmalfarbe/pandoc-latex-template/issues/122#issuecomment-538011690)~
    Resolved by wrapping really long lines in `\texttt{}`
- [x] ~Wrap long lines in code blocks with no language infostring (i.e., ```)~
    Resolved by replacing empty infostrings with "text"