### PR TITLE
feat: wrap cells of wide tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "genawaiter"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86bd0361bcbde39b13475e6e36cb24c329964aa2611be285289d1e4b751c1a0"
+dependencies = [
+ "genawaiter-macro",
+]
+
+[[package]]
+name = "genawaiter-macro"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b32dfe1fdfc0bbde1f22a5da25355514b5e450c33a6af6770884c8750aedfbc"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,6 +535,7 @@ version = "0.4.2"
 dependencies = [
  "anyhow",
  "env_logger",
+ "genawaiter",
  "insta",
  "log",
  "mdbook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ include = ["/src", "/CHANGELOG.md", "/LICENSE-*", "/README.md"]
 [dependencies]
 anyhow = "1.0.47"
 env_logger = "0.10.0"
+genawaiter = { version = "0.99.1", default-features = false }
 log = "0.4.0"
 mdbook = { version = "0.4.35", default-features = false }
 once_cell = "1.0.0"

--- a/README.md
+++ b/README.md
@@ -113,10 +113,6 @@ variable-name = "value"
 
 - When rendering to PDF through LaTeX, links to chapters sometimes link to slightly before the beginning of the chapter.
   See: https://github.com/jgm/pandoc/issues/9200
-- When rendering to PDF through LaTeX, tables with long rows will overflow the width of the page.
-  This is due to usage of pandoc's CommonMark parser, which doesn't yet support the functionality
-  needed to wrap cell contents that is implemented in the Pandoc Markdown parser.
-  See: https://github.com/jgm/commonmark-hs/issues/128
 
 ### Comparison to alternatives
 

--- a/src/pandoc/extension.rs
+++ b/src/pandoc/extension.rs
@@ -52,12 +52,7 @@ impl Extension {
     }
 
     pub fn check_availability(&self, pandoc: &semver::Version) -> Availability {
-        let version_req = self.version_requirement();
-        if version_req.matches(pandoc) {
-            Availability::Available
-        } else {
-            Availability::Unavailable(version_req)
-        }
+        Availability::check(self.version_requirement(), pandoc)
     }
 }
 
@@ -67,6 +62,13 @@ pub enum Availability {
 }
 
 impl Availability {
+    pub fn check(version_req: semver::VersionReq, pandoc: &semver::Version) -> Self {
+        if version_req.matches(pandoc) {
+            Availability::Available
+        } else {
+            Availability::Unavailable(version_req)
+        }
+    }
     pub fn is_available(&self) -> bool {
         match self {
             Self::Available => true,

--- a/src/pandoc/filters/annotate-tables-with-column-widths.lua
+++ b/src/pandoc/filters/annotate-tables-with-column-widths.lua
@@ -1,0 +1,28 @@
+-- needs pandoc 2.9.2
+function Blocks (blocks)
+  for i = #blocks, 1, -1 do
+    if i < #blocks then
+      -- check if current block is a `mdbook-pandoc::table: width1|width2|width3` annotation
+      if blocks[i].t == 'RawBlock' and blocks[i].format == 'html' and blocks[i+1].t == 'Table' then
+        local html = blocks[i].text
+        local table = blocks[i+1]
+        local _,end_idx = html:find('mdbook%-pandoc::table: ')
+        if end_idx ~= nil then
+          local widths = {}
+          local total_width = 0
+          for width in html:sub(end_idx+1):gmatch('(%d[^| ]*)') do
+            local width_n = tonumber(width)
+            widths[#widths+1] = width_n
+            total_width = total_width + width_n
+          end
+          for j,col in pairs(table.colspecs) do
+          	col[2] = widths[j] / total_width
+          end
+          -- remove annotation
+        	blocks:remove(i)
+        end
+      end
+    end
+  end
+  return blocks
+end

--- a/src/pandoc/profile.rs
+++ b/src/pandoc/profile.rs
@@ -7,6 +7,8 @@ use super::OutputFormat;
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Profile {
+    #[serde(default = "defaults::columns")]
+    pub columns: usize,
     #[serde(default = "defaults::enabled")]
     pub file_scope: bool,
     #[serde(default = "defaults::enabled")]
@@ -27,6 +29,11 @@ pub struct Profile {
 mod defaults {
     pub fn enabled() -> bool {
         true
+    }
+
+    pub fn columns() -> usize {
+        // https://pandoc.org/MANUAL.html#option--wrap
+        72
     }
 }
 

--- a/src/snapshots/mdbook_pandoc__tests__cargo_book.snap
+++ b/src/snapshots/mdbook_pandoc__tests__cargo_book.snap
@@ -167,10 +167,10 @@ expression: logs
  WARN mdbook_pandoc::preprocess: Unable to normalize link '../../reference/attributes/codegen.html#the-target_feature-attribute' in chapter 'Appendix: Glossary': Unable to canonicalize path: $ROOT/src/appendix/../../reference/attributes/codegen.html: No such file or directory (os error 2)    
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__commands__cargomd__option-cargo---offline'
-  on page 281 undefined on input line 19469.
+  on page 281 undefined on input line 19535.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__commands__cargo-buildmd__option-cargo-build---keep-going'
-  on page 285 undefined on input line 19706.
+  on page 285 undefined on input line 19772.
 [WARNING] [makePDF] LaTeX Warning: There were undefined references.
  INFO mdbook_pandoc::pandoc::renderer: Wrote output to book/pdf/book.pdf    
 

--- a/src/snapshots/mdbook_pandoc__tests__rust_book.snap
+++ b/src/snapshots/mdbook_pandoc__tests__rust_book.snap
@@ -38,16 +38,16 @@ expression: logs
  WARN mdbook_pandoc::preprocess: Unable to normalize link '../std/index.html' in chapter 'C - Derivable Traits': Unable to canonicalize path: $ROOT/src/../std/index.html: No such file or directory (os error 2)    
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__ch15-02-derefmd__following-the-pointer-to-the-value-with-the-dereference-operator'
-  on page 188 undefined on input line 10886.
+  on page 188 undefined on input line 10892.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__ch06-02-matchmd__the-match-control-flow-operator'
-  on page 589 undefined on input line 33738.
+  on page 589 undefined on input line 33744.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__ch13-01-closuresmd__moving-captured-values-out-of-the-closure-and-the-fn-traits'
-  on page 630 undefined on input line 36108.
+  on page 630 undefined on input line 36114.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__ch04-01-what-is-ownershipmd__ways-variables-and-data-interact-clone'
-  on page 680 undefined on input line 38925.
+  on page 682 undefined on input line 38979.
 [WARNING] [makePDF] LaTeX Warning: There were undefined references.
 [WARNING] Missing character: There is no 🚨 (U+1F6A8) (U+1F6A8) in font NotoSerif/B:mode=node;scri
 [WARNING] Missing character: There is no 👍 (U+1F44D) (U+1F44D) in font NotoSansMono:mode=node;scr

--- a/src/snapshots/mdbook_pandoc__tests__rust_embedded.snap
+++ b/src/snapshots/mdbook_pandoc__tests__rust_embedded.snap
@@ -5,28 +5,28 @@ expression: logs
  INFO mdbook::book: Running the pandoc backend    
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__design-patterns__hal__namingmd__c-crate-name'
-  on page 97 undefined on input line 5781.
+  on page 99 undefined on input line 5829.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__design-patterns__hal__interoperabilitymd__c-free'
-  on page 97 undefined on input line 5791.
+  on page 99 undefined on input line 5839.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__design-patterns__hal__interoperabilitymd__c-reexport-pac'
-  on page 97 undefined on input line 5794.
+  on page 99 undefined on input line 5842.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__design-patterns__hal__interoperabilitymd__c-hal-traits'
-  on page 97 undefined on input line 5797.
+  on page 99 undefined on input line 5845.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__design-patterns__hal__predictabilitymd__c-ctor'
-  on page 97 undefined on input line 5807.
+  on page 99 undefined on input line 5855.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__design-patterns__hal__gpiomd__c-zst-pin' on
-  page 97 undefined on input line 5817.
+  page 99 undefined on input line 5865.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__design-patterns__hal__gpiomd__c-erased-pin'
-  on page 98 undefined on input line 5820.
+  on page 100 undefined on input line 5868.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__design-patterns__hal__gpiomd__c-pin-state'
-  on page 98 undefined on input line 5823.
+  on page 100 undefined on input line 5871.
 [WARNING] [makePDF] LaTeX Warning: There were undefined references.
 [WARNING] Missing character: There is no 🦀 (U+1F980) (U+1F980) in font NotoSerif:mode=node;script
 [WARNING] Missing character: There is no ✓ (U+2713) (U+2713) in font NotoSerif:mode=node;script=l

--- a/src/snapshots/mdbook_pandoc__tests__rust_reference.snap
+++ b/src/snapshots/mdbook_pandoc__tests__rust_reference.snap
@@ -197,46 +197,46 @@ expression: logs
  WARN mdbook_pandoc::preprocess: Unable to normalize link '../alloc/alloc/trait.GlobalAlloc.html' in chapter 'The Rust runtime': Unable to canonicalize path: $ROOT/src/../alloc/alloc/trait.GlobalAlloc.html: No such file or directory (os error 2)    
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__type-layoutmd__the-default-representation'
-  on page 86 undefined on input line 5568.
+  on page 88 undefined on input line 5613.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__items__enumerationsmd__unit-only-enum' on
-  page 86 undefined on input line 5587.
+  page 88 undefined on input line 5632.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__items__enumerationsmd__unit-only-enum' on
-  page 87 undefined on input line 5683.
+  page 89 undefined on input line 5728.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__items__enumerationsmd__field-less-enum' on
-  page 87 undefined on input line 5704.
+  page 89 undefined on input line 5749.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__statementsmd__let-else-restriction' on page
-  161 undefined on input line 10862.
+  167 undefined on input line 10940.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__items__enumerationsmd__unit-only-enum' on
-  page 187 undefined on input line 12850.
+  page 194 undefined on input line 12975.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__items__enumerationsmd__field-less-enum' on
-  page 187 undefined on input line 12853.
+  page 194 undefined on input line 12978.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__type-layoutmd__the-rust-representation' on
-  page 265 undefined on input line 18224.
+  page 271 undefined on input line 18361.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__type-layoutmd__the-rust-representation' on
-  page 265 undefined on input line 18255.
+  page 271 undefined on input line 18392.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__items__enumerationsmd__field-less-enum' on
-  page 269 undefined on input line 18486.
+  page 275 undefined on input line 18623.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__items__enumerationsmd__field-less-enum' on
-  page 269 undefined on input line 18499.
+  page 275 undefined on input line 18636.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__items__enumerationsmd__field-less-enum' on
-  page 269 undefined on input line 18504.
+  page 275 undefined on input line 18641.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__items__enumerationsmd__field-less-enum' on
-  page 271 undefined on input line 18612.
+  page 277 undefined on input line 18749.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pdf__src__type-layoutmd__the-rust-representation' on
-  page 274 undefined on input line 18791.
+  page 280 undefined on input line 18928.
 [WARNING] [makePDF] LaTeX Warning: There were undefined references.
 [WARNING] Missing character: There is no 東 (U+6771) (U+6771) in font NotoSansMono:mode=node;scrip
 [WARNING] Missing character: There is no 京 (U+4EAC) (U+4EAC) in font NotoSansMono:mode=node;scrip

--- a/src/snapshots/mdbook_pandoc__tests__rustc_dev_guide.snap
+++ b/src/snapshots/mdbook_pandoc__tests__rustc_dev_guide.snap
@@ -26,208 +26,208 @@ expression: logs
  WARN mdbook_pandoc::preprocess: Unable to normalize link '../guides/editions.md#edition-specific-lints' in chapter 'Errors and Lints': Unable to canonicalize path: $ROOT/src/../guides/editions.md: No such file or directory (os error 2)    
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__ice' on page
-  25 undefined on input line 1345.
+  26 undefined on input line 1351.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__conventionsmd__formatting' on page
-  41 undefined on input line 2366.
+  41 undefined on input line 2378.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__tests__addingmd__explanatory_comment'
-  on page 52 undefined on input line 3222.
+  on page 53 undefined on input line 3240.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__building__how-to-build-and-runmd__toolchain'
-  on page 103 undefined on input line 6596.
+  on page 104 undefined on input line 6614.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__gitmd__conflicts' on page 131
-  undefined on input line 8263.
+  `book__pandoc__pdf__src__gitmd__conflicts' on page 133
+  undefined on input line 8299.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__walkthroughmd__impl' on page 144
-  undefined on input line 8880.
+  `book__pandoc__pdf__src__walkthroughmd__impl' on page 146
+  undefined on input line 8916.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__conventionsmd__formatting' on page
-  162 undefined on input line 9878.
+  164 undefined on input line 9914.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__conventionsmd__cc' on page 162
-  undefined on input line 9880.
+  `book__pandoc__pdf__src__conventionsmd__cc' on page 164
+  undefined on input line 9916.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__conventionsmd__cio' on page 162
-  undefined on input line 9882.
+  `book__pandoc__pdf__src__conventionsmd__cio' on page 164
+  undefined on input line 9918.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__conventionsmd__er' on page 162
-  undefined on input line 9884.
-[WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__notification-groups__aboutmd__join'
-  on page 185 undefined on input line 10850.
+  `book__pandoc__pdf__src__conventionsmd__er' on page 164
+  undefined on input line 9920.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__notification-groups__aboutmd__join'
-  on page 185 undefined on input line 10855.
+  on page 187 undefined on input line 10886.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__notification-groups__aboutmd__join'
+  on page 187 undefined on input line 10891.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__intrinsic' on
-  page 218 undefined on input line 12823.
+  page 220 undefined on input line 12859.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__queries__incremental-compilationmd__dag'
-  on page 236 undefined on input line 13947.
+  on page 238 undefined on input line 13983.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__querymd__adding-a-new-kind-of-query'
-  on page 246 undefined on input line 14535.
+  on page 248 undefined on input line 14571.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__generic_argumentsmd__GenericArgs'
-  on page 257 undefined on input line 15152.
+  on page 259 undefined on input line 15188.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__cfg' on
-  page 321 undefined on input line 18910.
+  page 324 undefined on input line 18996.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__cfg' on
-  page 321 undefined on input line 18938.
+  page 324 undefined on input line 19024.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__mir__indexmd__promoted' on page 325
-  undefined on input line 19173.
-[WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__appendix__glossarymd__newtype' on
-  page 325 undefined on input line 19186.
+  `book__pandoc__pdf__src__mir__indexmd__promoted' on page 328
+  undefined on input line 19259.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__newtype' on
-  page 325 undefined on input line 19196.
+  page 328 undefined on input line 19272.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__newtype' on
-  page 325 undefined on input line 19216.
+  page 328 undefined on input line 19282.
+[WARNING] [makePDF] LaTeX Warning: Hyper reference
+  `book__pandoc__pdf__src__appendix__glossarymd__newtype' on
+  page 328 undefined on input line 19302.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__placeholder'
-  on page 389 undefined on input line 22925.
+  on page 392 undefined on input line 23015.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__type-inferencemd__vars' on page 405
-  undefined on input line 24177.
+  `book__pandoc__pdf__src__type-inferencemd__vars' on page 408
+  undefined on input line 24267.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__free-vs-bound'
-  on page 406 undefined on input line 24215.
+  on page 409 undefined on input line 24305.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__traits__canonical-queriesmd__query-response'
-  on page 407 undefined on input line 24295.
+  on page 410 undefined on input line 24385.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__traits__canonical-queriesmd__query-response'
-  on page 407 undefined on input line 24336.
+  on page 410 undefined on input line 24426.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__variancemd__addendum' on page 431
-  undefined on input line 25966.
+  `book__pandoc__pdf__src__variancemd__addendum' on page 434
+  undefined on input line 26056.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__opaque-types-impl-trait-inferencemd__Within-the-type_of-query'
-  on page 439 undefined on input line 26512.
+  on page 442 undefined on input line 26602.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__region' on
-  page 472 undefined on input line 28266.
+  page 475 undefined on input line 28356.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__inf-var' on
-  page 472 undefined on input line 28269.
+  page 475 undefined on input line 28359.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__dataflow'
-  on page 472 undefined on input line 28273.
+  on page 475 undefined on input line 28363.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__free-vs-bound'
-  on page 480 undefined on input line 28865.
+  on page 483 undefined on input line 28955.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__point' on
-  page 485 undefined on input line 29267.
+  page 488 undefined on input line 29357.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__borrow_check__region_inference__member_constraintsmd__collecting'
-  on page 493 undefined on input line 29832.
+  on page 496 undefined on input line 29922.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__quantified'
-  on page 495 undefined on input line 29936.
+  on page 498 undefined on input line 30026.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__variance'
-  on page 495 undefined on input line 29958.
+  on page 498 undefined on input line 30048.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__free-vs-bound'
-  on page 495 undefined on input line 30008.
+  on page 498 undefined on input line 30098.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__diagnosticsmd__future-incompatible'
-  on page 510 undefined on input line 30961.
+  on page 513 undefined on input line 31051.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__mono' on page
-  549 undefined on input line 33554.
+  552 undefined on input line 33644.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__def-id' on
-  page 549 undefined on input line 33568.
+  page 552 undefined on input line 33658.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__codegen-unit'
-  on page 562 undefined on input line 34284.
+  on page 565 undefined on input line 34374.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__cfg' on
-  page 619 undefined on input line 37629.
+  page 622 undefined on input line 37725.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__free-vs-bound'
-  on page 625 undefined on input line 37990.
+  on page 628 undefined on input line 38092.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__free-vs-bound'
-  on page 625 undefined on input line 38000.
+  on page 628 undefined on input line 38102.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__cfg' on
-  page 625 undefined on input line 38014.
+  page 628 undefined on input line 38116.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__TyCtxt' on
-  page 625 undefined on input line 38022.
+  page 628 undefined on input line 38124.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__cx' on page
-  625 undefined on input line 38023.
+  628 undefined on input line 38125.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__tcx' on page
-  625 undefined on input line 38024.
+  628 undefined on input line 38126.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__dataflow'
-  on page 625 undefined on input line 38032.
+  on page 628 undefined on input line 38134.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__what-is-a-debruijn-index'
-  on page 625 undefined on input line 38037.
+  on page 628 undefined on input line 38139.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__variant-idx'
-  on page 625 undefined on input line 38048.
+  on page 628 undefined on input line 38150.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__tag' on page
-  625 undefined on input line 38050.
+  628 undefined on input line 38152.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__free-vs-bound'
-  on page 625 undefined on input line 38082.
+  on page 628 undefined on input line 38184.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__tag' on page
-  625 undefined on input line 38197.
+  628 undefined on input line 38299.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__traits__goals-and-clausesmd__trait-ref'
-  on page 625 undefined on input line 38227.
+  on page 628 undefined on input line 38329.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__mir__indexmd__promoted' on page 625
-  undefined on input line 38230.
+  `book__pandoc__pdf__src__mir__indexmd__promoted' on page 628
+  undefined on input line 38332.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__quantified'
-  on page 625 undefined on input line 38238.
+  on page 628 undefined on input line 38340.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__discriminant'
-  on page 625 undefined on input line 38293.
+  on page 628 undefined on input line 38395.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__niche' on
-  page 625 undefined on input line 38296.
+  page 628 undefined on input line 38398.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__traits__goals-and-clausesmd__trait-ref'
-  on page 625 undefined on input line 38320.
+  on page 628 undefined on input line 38422.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__tcx' on page
-  625 undefined on input line 38328.
+  628 undefined on input line 38430.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__backgroundmd__variance'
-  on page 625 undefined on input line 38347.
+  on page 628 undefined on input line 38449.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__discriminant'
-  on page 625 undefined on input line 38353.
+  on page 628 undefined on input line 38455.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__hirmd__hir-id' on page 628
-  undefined on input line 38386.
+  `book__pandoc__pdf__src__hirmd__hir-id' on page 687
+  undefined on input line 38503.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__hirmd__hir-id' on page 628
-  undefined on input line 38402.
+  `book__pandoc__pdf__src__hirmd__hir-id' on page 687
+  undefined on input line 38519.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__hirmd__hir-id' on page 628
-  undefined on input line 38414.
+  `book__pandoc__pdf__src__hirmd__hir-id' on page 687
+  undefined on input line 38531.
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
-  `book__pandoc__pdf__src__hirmd__hir-id' on page 628
-  undefined on input line 38419.
+  `book__pandoc__pdf__src__hirmd__hir-id' on page 687
+  undefined on input line 38536.
 [WARNING] [makePDF] LaTeX Warning: There were undefined references.
 [WARNING] Missing character: There is no 🔑 (U+1F511) (U+1F511) in font NotoSerif:mode=node;script
 [WARNING] Missing character: There is no ✅ (U+2705) (U+2705) in font NotoSerif:mode=node;script=l


### PR DESCRIPTION
Emulates [Pandoc's cell-wrapping behavior for tables](https://pandoc.org/MANUAL.html#extension-pipe_tables) to prevent wide tables from overflowing the page