### PR TITLE
chore(deps): update `pulldown-cmark-to-cmark`, `toml`, and `regex` dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,7 +508,7 @@ dependencies = [
  "serde_json",
  "shlex",
  "tempfile",
- "toml",
+ "toml 0.5.11",
  "topological-sort",
 ]
 
@@ -534,7 +534,7 @@ dependencies = [
  "serde_yaml",
  "tempfile",
  "thiserror",
- "toml",
+ "toml 0.8.12",
  "tracing",
  "tracing-log",
  "tracing-subscriber",
@@ -678,9 +678,9 @@ checksum = "d5d8f9aa0e3cbcfaf8bf00300004ee3b72f74770f9cbac93f6928771f613276b"
 
 [[package]]
 name = "pulldown-cmark-to-cmark"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a04bbc5bee6af7185cffcd5626f893cb3d3f4c2d84500a6199fd4cfc8f86141"
+checksum = "f609795c8d835f79dcfcf768415b9fb57ef1b74891e99f86e73f43a7a257163b"
 dependencies = [
  "pulldown-cmark",
 ]
@@ -835,6 +835,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,6 +991,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c12219811e0c1ba077867254e5ad62ee2c9c190b0d957110750ac0cda1ae96cd"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -1383,6 +1426,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+
+[[package]]
+name = "winnow"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ mdbook = { version = "0.4.35", default-features = false }
 once_cell = "1.0.0"
 pulldown-cmark = { version = "0.10.0", default-features = false }
 pulldown-cmark-to-cmark = "12.0.0"
-regex = "1.0.0"
+regex = "1.5.5"
 semver = "1.0.0"
 serde = { version = "1.0.85", features = ["derive"] }
 serde_derive = "1.0.85"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ log = "0.4.0"
 mdbook = { version = "0.4.35", default-features = false }
 once_cell = "1.0.0"
 pulldown-cmark = { version = "0.10.0", default-features = false }
-pulldown-cmark-to-cmark = "12.0.0"
+pulldown-cmark-to-cmark = "13.0.0"
 regex = "1.5.5"
 semver = "1.0.0"
 serde = { version = "1.0.85", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ serde = { version = "1.0.85", features = ["derive"] }
 serde_derive = "1.0.85"
 serde_yaml = "0.9.0"
 tempfile = "3.0.0"
-toml = "0.5.0"
+toml = "0.8.0"
 ureq = "2.0.0"
 walkdir = "2.0.0"
 


### PR DESCRIPTION
- Update `regex` version requirement to avoid [security advisory](https://rustsec.org/advisories/RUSTSEC-2022-0013.html)
- Update `pulldown-cmark-to-cmark` to 13.0.0
- Update `toml` to 0.8