### PR TITLE
fix(windows): normalize paths with `normpath` instead of `std::fs::canonicalize()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,6 +522,7 @@ dependencies = [
  "insta",
  "log",
  "mdbook",
+ "normpath",
  "once_cell",
  "proc-macro2",
  "pulldown-cmark",
@@ -558,11 +559,11 @@ dependencies = [
 
 [[package]]
 name = "normpath"
-version = "1.2.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5831952a9476f2fed74b77d74182fa5ddc4d21c72ec45a333b250e3ed0272804"
+checksum = "ec60c60a693226186f5d6edf073232bfb6464ed97eb22cf3b01c1e8198fd97f5"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ env_logger = "0.11.0"
 genawaiter = { version = "0.99.1", default-features = false }
 log = "0.4.0"
 mdbook = { version = "0.4.35", default-features = false }
+normpath = "1.0.0, <1.2.0" # 1.2.0 raises MSRV to 1.74
 once_cell = "1.0.0"
 pulldown-cmark = { version = "0.10.0", default-features = false }
 pulldown-cmark-to-cmark = "13.0.0"

--- a/src/book.rs
+++ b/src/book.rs
@@ -1,5 +1,7 @@
 use std::{fs, path::PathBuf};
 
+use normpath::PathExt;
+
 pub struct Book<'book> {
     pub book: &'book mdbook::book::Book,
     pub root: PathBuf,
@@ -9,11 +11,11 @@ pub struct Book<'book> {
 
 impl<'book> Book<'book> {
     pub fn new(ctx: &'book mdbook::renderer::RenderContext) -> anyhow::Result<Self> {
-        let root = ctx.root.canonicalize()?;
-        let source_dir = ctx.source_dir().canonicalize()?;
+        let root = ctx.root.normalize()?.into_path_buf();
+        let source_dir = ctx.source_dir().normalize()?.into_path_buf();
 
         fs::create_dir_all(&ctx.destination)?;
-        let destination = ctx.destination.canonicalize()?;
+        let destination = ctx.destination.normalize()?.into_path_buf();
 
         Ok(Self {
             book: &ctx.book,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,6 +186,7 @@ mod tests {
     };
 
     use mdbook::{BookItem, Renderer as _};
+    use normpath::PathExt;
     use once_cell::sync::Lazy;
     use regex::Regex;
     use tempfile::{tempfile, TempDir};
@@ -372,7 +373,7 @@ mod tests {
                 writeln!(&mut logs, "{err:#}").unwrap()
             }
 
-            let root = self.book.root.canonicalize().unwrap();
+            let root = self.book.root.normalize().unwrap().into_path_buf();
             let re = Regex::new(&format!(
                 r"(?P<root>{})|(?P<line>line\s+\d+)|(?P<page>page\s+\d+)",
                 root.display()
@@ -566,7 +567,7 @@ mod tests {
         insta::assert_snapshot!(book, @r###"
         ├─ log output
         │  INFO mdbook::book: Running the pandoc backend    
-        │  WARN mdbook_pandoc::preprocess: Unable to normalize link 'foobarbaz' in chapter 'Getting Started': Unable to canonicalize path: $ROOT/src/foobarbaz: No such file or directory (os error 2)    
+        │  WARN mdbook_pandoc::preprocess: Unable to normalize link 'foobarbaz' in chapter 'Getting Started': Unable to normalize path: $ROOT/src/foobarbaz: No such file or directory (os error 2)    
         │  WARN mdbook_pandoc: Unable to resolve one or more relative links within the book, consider setting the `hosted-html` option in `[output.pandoc]`    
         │  INFO mdbook_pandoc::pandoc::renderer: Wrote output to book/markdown/book.md    
         ├─ markdown/book.md

--- a/src/pandoc/renderer.rs
+++ b/src/pandoc/renderer.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use anyhow::Context as _;
+use normpath::PathExt;
 use tempfile::NamedTempFile;
 
 use crate::{
@@ -219,7 +220,7 @@ impl Renderer {
                     include_str!("filters/annotate-tables-with-column-widths.lua")
                 )?;
                 pandoc.arg("--lua-filter");
-                pandoc.arg(filter.path().canonicalize()?);
+                pandoc.arg(filter.path().normalize()?.as_path());
                 _filter_tempfile_guard = filter.into_temp_path();
             } else {
                 log::warn!(


### PR DESCRIPTION
On Windows, `std::fs::canonicalize()` [produces a weird type of path that cannot be used with `Command::current_dir()`](https://github.com/rust-lang/rust/issues/42869). This switches to using the [`normpath`](https://docs.rs/normpath/latest/normpath/trait.PathExt.html#tymethod.normalize) crate, which should avoid these issues.