### PR TITLE
fix(docs): minimum `pandoc` version is actually 2.8, not 1.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See [Rendered Books](#rendered-books) for samples of rendered books.
 - [Install `pandoc`](https://pandoc.org/installing.html)
 
   > **Note**: `mdbook-pandoc` works best with Pandoc 2.10.1 or newer.
-  > Older versions (as old as 1.14) are partially supported, but will result in degraded output.
+  > Older versions (as old as 2.8) are partially supported, but will result in degraded output.
   >
   > If you have an old version of Pandoc installed (in particular, Ubuntu releases before 23.04 have older-than-recommended Pandoc versions in their package repositories), consider downloading a newer version from Pandoc's installation page.
 

--- a/src/pandoc.rs
+++ b/src/pandoc.rs
@@ -13,10 +13,10 @@ pub use renderer::{Context as RenderContext, OutputFormat, Renderer};
 
 /// Minimum compatible version of Pandoc
 const MINIMUM_VERSION: Version =
-    // commonmark input format introduced in 1.14
+    // Defaults files introduced in 2.8
     Version {
-        major: 1,
-        minor: 14,
+        major: 2,
+        minor: 8,
         patch: 0,
     };
 


### PR DESCRIPTION
Defaults files (`--defaults`/`-d`) were introduced in [2.8](https://pandoc.org/releases.html#pandoc-2.8-2019-11-22)