### PR TITLE
feat: preserve escape characters (or lack thereof) from Markdown source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,9 +678,9 @@ checksum = "d5d8f9aa0e3cbcfaf8bf00300004ee3b72f74770f9cbac93f6928771f613276b"
 
 [[package]]
 name = "pulldown-cmark-to-cmark"
-version = "13.0.0"
+version = "14.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f609795c8d835f79dcfcf768415b9fb57ef1b74891e99f86e73f43a7a257163b"
+checksum = "03ac1dab098faca0c377449f5dbe98a222a3f6d67089c2e308bd3c7076cd37bd"
 dependencies = [
  "pulldown-cmark",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ mdbook = { version = "0.4.35", default-features = false }
 normpath = "1.0.0, <1.2.0" # 1.2.0 raises MSRV to 1.74
 once_cell = "1.0.0"
 pulldown-cmark = { version = "0.10.0, <0.10.2", default-features = false } # 0.10.2 raises MSRV to 1.74
-pulldown-cmark-to-cmark = "13.0.0"
+pulldown-cmark-to-cmark = "14.0.1"
 regex = "1.5.5"
 semver = "1.0.0"
 serde = { version = "1.0.85", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -535,6 +535,19 @@ mod tests {
             .try_into()
             .unwrap()
         }
+
+        fn pandoc() -> Self {
+            toml! {
+                keep-preprocessed = false
+
+                [profile.markdown]
+                output-file = "pandoc-ir"
+                to = "native"
+                standalone = false
+            }
+            .try_into()
+            .unwrap()
+        }
     }
 
     #[test]
@@ -1127,6 +1140,28 @@ fn main() {}
         ├─ latex/src/chapter.md
         │ [link](book/latex/src/chapter.md "\"foo\" (bar)")
         │ 
+        "###);
+    }
+
+    #[test]
+    fn preserve_escapes() {
+        let output = MDBook::init()
+            .config(Config::pandoc())
+            .chapter(Chapter::new("", "[Prefix @fig:1] [-@fig:1]", "chapter.md"))
+            .build();
+        insta::assert_snapshot!(output, @r###"
+        ├─ log output
+        │  INFO mdbook::book: Running the pandoc backend    
+        │  INFO mdbook_pandoc::pandoc::renderer: Wrote output to book/markdown/pandoc-ir    
+        ├─ markdown/pandoc-ir
+        │ [ Para
+        │     [ Str "[Prefix"
+        │     , Space
+        │     , Str "@fig:1]"
+        │     , Space
+        │     , Str "[-@fig:1]"
+        │     ]
+        │ ]
         "###);
     }
 


### PR DESCRIPTION
Using https://github.com/Byron/pulldown-cmark-to-cmark/pull/71, attempts to preserve escape characters (or lack thereof) from the Markdown source, e.g. keeping ``[`Vec`]`` as ``[`Vec`]`` and ``\[`Vec`\]`` as ``\[`Vec`\]``.

Closes #91