### PR TITLE
feat: allow overriding source format and extensions through Pandoc's `from` option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,6 +532,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_yaml",
+ "similar",
  "tempfile",
  "thiserror",
  "toml 0.8.12",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ proc-macro2 = "1.0.60"
 
 [dev-dependencies]
 insta = { version = "1.36.0" }
+similar = { version = "2.5.0", features = ["text"] }
 tracing = { version = "0.1.0", default-features = false, features = ["std"] }
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["fmt", "tracing-log"] }

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ to = "latex" # output format
 pdf-engine = "pdflatex" # engine to use to produce PDF output
 
 # `mdbook-pandoc` overrides Pandoc's defaults for the following options to better support mdBooks
+from = "commonmark" # source format; extensions enabled/disabled through this option are preserved
 file-scope = true # parse each file individually before combining
 number-sections = true # number sections headings
 standalone = true # produce output with an appropriate header and footer

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -797,6 +797,25 @@ This is an example of a footnote[^note].
     }
 
     #[test]
+    fn docx_bookmarks() {
+        let book = MDBook::init()
+            .chapter(Chapter::new("", "# One", "one.md"))
+            .config(
+                toml! {
+                    keep-preprocessed = false
+
+                    [profile.markdown]
+                    output-file = "book.docx"
+                    from = "markdown-auto_identifiers"
+                }
+                .try_into()
+                .unwrap(),
+            )
+            .build();
+        insta::assert_snapshot!(book, @r###""###);
+    }
+
+    #[test]
     fn inter_chapter_links() {
         let book = MDBook::init()
             .chapter(Chapter::new("One", "[Two](../two/two.md)", "one/one.md"))

--- a/src/pandoc.rs
+++ b/src/pandoc.rs
@@ -69,6 +69,10 @@ impl Context {
             .or_insert_with(|| extension.check_availability(&self.version))
     }
 
+    pub fn retain_extensions(&mut self, mut f: impl FnMut(&Extension) -> bool) {
+        self.enabled_extensions.retain(|extension, _| f(extension))
+    }
+
     pub fn enabled_extensions(
         &self,
     ) -> impl Iterator<Item = (&Extension, &extension::Availability)> + '_ {

--- a/src/pandoc/profile.rs
+++ b/src/pandoc/profile.rs
@@ -17,6 +17,7 @@ pub struct Profile {
     pub pdf_engine: Option<PathBuf>,
     #[serde(default = "defaults::enabled")]
     pub standalone: bool,
+    pub from: Option<String>,
     pub to: Option<String>,
     #[serde(default = "defaults::enabled")]
     pub table_of_contents: bool,

--- a/src/pandoc/renderer.rs
+++ b/src/pandoc/renderer.rs
@@ -116,9 +116,7 @@ impl Renderer {
                         log::warn!(
                             "Cannot use Pandoc extension `{}`, which may result in degraded output \
                             (introduced in version {}, but using {})",
-                            extension.name(),
-                            introduced_in,
-                            ctx.pandoc.version,
+                            extension.name(), introduced_in, ctx.pandoc.version,
                         );
                     }
                 }


### PR DESCRIPTION
If `from` is set in a profile, respect the format and extensions it implies. For example, if `from = commonmark-gfm_auto_identifiers`, `mdbook-pandoc` will disable `gfm_auto_identifiers` event if it otherwise would have enabled it. Fixes #97