### PR TITLE
fix: correctly resolve absolute-path links to be relative to book root

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -834,7 +834,11 @@ This is an example of a footnote[^note].
     fn inter_chapter_links() {
         let book = MDBook::init()
             .chapter(Chapter::new("One", "[Two](../two/two.md)", "one/one.md"))
-            .chapter(Chapter::new("Two", "[One](../one/one.md)", "two/two.md"))
+            .chapter(Chapter::new(
+                "Two",
+                "[One](../one/one.md)\n[also one](/one/one.md)",
+                "two/two.md",
+            ))
             .config(Config::latex())
             .build();
         insta::assert_snapshot!(book, @r###"
@@ -847,10 +851,12 @@ This is an example of a footnote[^note].
         │ 
         │ \phantomsection\label{book__latex__src__two__twomd}
         │ \hyperref[book__latex__src__one__onemd]{One}
+        │ \hyperref[book__latex__src__one__onemd]{also one}
         ├─ latex/src/one/one.md
         │ [Two](book/latex/src/two/two.md)
         ├─ latex/src/two/two.md
         │ [One](book/latex/src/one/one.md)
+        │ [also one](book/latex/src/one/one.md)
         "###);
     }
 

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -247,19 +247,23 @@ impl<'book> Preprocessor<'book> {
             }
         } else {
             // URI is a relative-reference: https://datatracker.ietf.org/doc/html/rfc3986#section-4.2
-            if link.starts_with('/') {
-                // URI is a network-path reference or absolute-path reference;
-                // leave both untouched
+            if link.starts_with("//") {
+                // URI is a network-path reference; leave it untouched
                 Ok(link)
             } else {
-                // URI is a relative-path reference, which must be normalized
+                // URI is an absolute-path or relative-path reference, which must be resolved
+                // relative to the book root or the current chapter's directory, respectively
                 let path_range = link_path_range();
                 let link_path = match &link[path_range] {
                     // Internal reference within chapter
                     "" if link.starts_with('#') => return Ok(link),
                     path => Path::new(path),
                 };
-                let path = chapter_dir.join(link_path);
+                let path = if let Ok(relative_to_root) = link_path.strip_prefix("/") {
+                    self.preprocessed.join(relative_to_root)
+                } else {
+                    chapter_dir.join(link_path)
+                };
 
                 let normalized = self
                     .normalize_path(&self.ctx.book.source_dir.join(&path))

--- a/src/snapshots/mdbook_pandoc__tests__rustc_dev_guide.snap
+++ b/src/snapshots/mdbook_pandoc__tests__rustc_dev_guide.snap
@@ -23,6 +23,7 @@ expression: logs
  WARN mdbook_pandoc::preprocess: Heading (level h5) converted to paragraph in chapter: Return Position Impl Trait In Trait    
  WARN mdbook_pandoc::preprocess: Heading (level h5) converted to paragraph in chapter: Return Position Impl Trait In Trait    
  WARN mdbook_pandoc::preprocess: Heading (level h5) converted to paragraph in chapter: Return Position Impl Trait In Trait    
+ INFO mdbook_pandoc::preprocess: Unable to resolve relative path '/home/matthew/rust/compiler/rustc_hir_analysis/src/coherence/unsafety.rs' in chapter 'unsafety-checking.md', linking to hosted HTML book at 'https://rustc-dev-guide.rust-lang.org/$ROOT/book/pandoc/pdf/src/home/matthew/rust/compiler/rustc_hir_analysis/src/coherence/unsafety.rs'    
  INFO mdbook_pandoc::preprocess: Unable to resolve relative path '../guides/editions.md' in chapter 'diagnostics.md', linking to hosted HTML book at 'https://rustc-dev-guide.rust-lang.org/../guides/editions.md'    
 [WARNING] [makePDF] LaTeX Warning: Hyper reference
   `book__pandoc__pdf__src__appendix__glossarymd__ice' on $PAGE undefined on input $LINE.


### PR DESCRIPTION
If a book contains `chapter.md` at the top-level, a link like `[link](/chapter.md]` should point to that chapter. This fixes `mdbook-pandoc`'s handling of such links