### PR TITLE
Check for `disabled = true` before invoking `pandoc`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,8 +92,6 @@ impl mdbook::Renderer for Renderer {
             );
         }
 
-        let pandoc_version = pandoc::check_compatibility()?;
-
         let cfg: Config = ctx
             .config
             .get_deserialized_opt(Self::CONFIG_KEY)
@@ -104,6 +102,8 @@ impl mdbook::Renderer for Renderer {
             log::info!("Skipping rendering since `disabled` is set");
             return Ok(());
         }
+
+        let pandoc_version = pandoc::check_compatibility()?;
 
         let html_cfg: Option<HtmlConfig> = ctx
             .config


### PR DESCRIPTION
I tried the new version of `mdbook-pandoc`, and found that it fails on my laptop which didn't have `pandoc` installed.