### PR TITLE
chore(deps)!: upgrade `pulldown-cmark` and `pulldown-cmark-to-cmark`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,7 +544,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "opener",
- "pulldown-cmark",
+ "pulldown-cmark 0.10.3",
  "regex",
  "serde",
  "serde_json",
@@ -569,7 +569,7 @@ dependencies = [
  "normpath",
  "once_cell",
  "proc-macro2",
- "pulldown-cmark",
+ "pulldown-cmark 0.12.1",
  "pulldown-cmark-to-cmark",
  "regex",
  "semver",
@@ -723,6 +723,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666f0f59e259aea2d72e6012290c09877a780935cc3c18b1ceded41f3890d59c"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "pulldown-cmark-escape"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,11 +741,11 @@ checksum = "bd348ff538bc9caeda7ee8cad2d1d48236a1f443c1fa3913c6a02fe0043b1dd3"
 
 [[package]]
 name = "pulldown-cmark-to-cmark"
-version = "14.0.1"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ac1dab098faca0c377449f5dbe98a222a3f6d67089c2e308bd3c7076cd37bd"
+checksum = "41b27c0d365d60ff3e085007911d73419e5664de48155d558ebfa84d117a5109"
 dependencies = [
- "pulldown-cmark",
+ "pulldown-cmark 0.12.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ log = "0.4.0"
 mdbook = { version = "0.4.35", default-features = false }
 normpath = "1.0.0"
 once_cell = "1.0.0"
-pulldown-cmark = { version = "0.10.0", default-features = false }
-pulldown-cmark-to-cmark = "14.0.1"
+pulldown-cmark = { version = "0.12.0", default-features = false }
+pulldown-cmark-to-cmark = "17.0.0"
 regex = "1.5.5"
 semver = "1.0.0"
 serde = { version = "1.0.85", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1162,7 +1162,7 @@ fn main() {}
                 "chapter.md",
             ))
             .build();
-        insta::assert_snapshot!(book, @r###"
+        insta::assert_snapshot!(book, @r##"
         ├─ log output
         │  INFO mdbook::book: Running the pandoc backend    
         │  INFO mdbook_pandoc::pandoc::renderer: Wrote output to book/latex/output.tex    
@@ -1173,9 +1173,12 @@ fn main() {}
         ├─ latex/src/chapter.md
         │ # Chapter Foo
         │ 
-        │ [link](book/latex/src/chapter.md#chapter-foo "\"foo\" (bar)")
+        │ [link][link-with-description]
         │ 
-        "###);
+        │ 
+        │ 
+        │ [link-with-description]: book/latex/src/chapter.md#chapter-foo "\"foo\" (bar)"
+        "##);
     }
 
     #[test]


### PR DESCRIPTION
Wait for `mdbook` 0.5 ([which will upgrade `pulldown-cmark`](https://github.com/rust-lang/mdBook/pull/2401#issuecomment-2312564946)) to be consistent in parsing behavior