### PR TITLE
Fix infinite recursion in Preprocessor when book.toml is next to book destination

### DIFF
--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -105,7 +105,7 @@ impl<'book> Preprocessor<'book> {
         for entry in WalkDir::new(&ctx.book.source_dir).follow_links(true) {
             let entry = entry?;
             let src = entry.path();
-            if src.starts_with(&ctx.book.destination.as_path()) {
+            if src.starts_with(ctx.book.destination.as_path()) {
                 continue;
             }
             let dest = preprocessed.join(src.strip_prefix(&ctx.book.source_dir).unwrap());

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -105,6 +105,9 @@ impl<'book> Preprocessor<'book> {
         for entry in WalkDir::new(&ctx.book.source_dir).follow_links(true) {
             let entry = entry?;
             let src = entry.path();
+            if src.starts_with(&ctx.book.destination.as_path()) {
+                continue;
+            }
             let dest = preprocessed.join(src.strip_prefix(&ctx.book.source_dir).unwrap());
             if entry.file_type().is_dir() {
                 fs::create_dir_all(&dest)


### PR DESCRIPTION
I have a book layout that looks as:
- book.toml
- foo.md
- bar/bar.md

That results in an infinite recursion while copying the files to the "book/pdf" destination directory as that directory repeatedly get copied into itself.

The attached patch fixes this by checking if the file to be copied is within the destination directory and skipping it accordingly.

