### PR TITLE
feat!: support `<img>` tags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c66d1cd8ed61bf80b38432613a7a2f09401ab8d0501110655f8b341484a3e3"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dbus"
 version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,6 +289,21 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "dtoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
 ]
 
 [[package]]
@@ -563,6 +601,7 @@ version = "0.7.3"
 dependencies = [
  "aho-corasick",
  "anyhow",
+ "cssparser",
  "env_logger",
  "genawaiter",
  "html5gum",
@@ -696,6 +735,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,6 +838,21 @@ checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "regex"
@@ -953,6 +1049,18 @@ name = "similar"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "spin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ include = ["/src", "/CHANGELOG.md", "/LICENSE-*", "/README.md"]
 [dependencies]
 aho-corasick = "1.0.0"
 anyhow = "1.0.47"
+cssparser = "0.34.0"
 env_logger = "0.11.0"
 genawaiter = { version = "0.99.1", default-features = false }
 html5gum = "0.5.7"

--- a/src/css.rs
+++ b/src/css.rs
@@ -1,0 +1,170 @@
+use std::{
+    collections::{BTreeMap, HashMap},
+    fs,
+    path::Path,
+};
+
+use cssparser::CowRcStr;
+
+#[derive(Debug, Default)]
+pub struct Css<'i> {
+    pub stylesheets: Vec<&'i Path>,
+    pub styles: Styles<'i>,
+}
+
+#[derive(Debug, Default)]
+pub struct Styles<'i> {
+    pub classes: HashMap<CowRcStr<'i>, BTreeMap<CowRcStr<'i>, &'i str>>,
+}
+
+pub fn read_stylesheets<'a>(
+    config: &'a mdbook::config::HtmlConfig,
+    book: &'a crate::Book,
+) -> impl Iterator<Item = (&'a Path, String)> {
+    config.additional_css.iter().flat_map(|stylesheet| {
+        match fs::read_to_string(book.root.join(stylesheet)) {
+            Ok(css) => Some((stylesheet.as_path(), css)),
+            Err(err) => {
+                log::warn!(
+                    "Failed to read CSS stylesheet '{}': {err}",
+                    stylesheet.display()
+                );
+                None
+            }
+        }
+    })
+}
+
+impl<'i> Css<'i> {
+    pub fn load(&mut self, stylesheet: &'i Path, css: &'i str) {
+        self.stylesheets.push(stylesheet);
+        let parser = Parser { stylesheet };
+        for res in cssparser::StyleSheetParser::new(
+            &mut cssparser::Parser::new(&mut cssparser::ParserInput::new(css)),
+            &mut &parser,
+        ) {
+            match res {
+                Err((err, css)) => parser.warn_invalid_css(err, css),
+                Ok(DeclOrRule::Decl(..)) => {}
+                Ok(DeclOrRule::Rule(prelude, decls)) => {
+                    for selector in prelude {
+                        match selector {
+                            Selector::Class(class) => {
+                                let props = self.styles.classes.entry(class).or_default();
+                                for (prop, val) in &decls {
+                                    props.insert(prop.clone(), val);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct Parser<'a> {
+    stylesheet: &'a Path,
+}
+
+impl Parser<'_> {
+    fn warn_invalid_css(&self, err: cssparser::ParseError<'_, anyhow::Error>, css: &str) {
+        log::warn!(
+            "Failed to parse CSS from '{stylesheet}': {err}: {css}",
+            stylesheet = self.stylesheet.display()
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum Selector<'i> {
+    Class(CowRcStr<'i>),
+}
+
+type Selectors<'i> = Vec<Selector<'i>>;
+
+#[derive(Debug)]
+enum DeclOrRule<'i> {
+    Decl(CowRcStr<'i>, &'i str),
+    Rule(Selectors<'i>, HashMap<CowRcStr<'i>, &'i str>),
+}
+
+impl<'i> cssparser::QualifiedRuleParser<'i> for &Parser<'_> {
+    type Prelude = Selectors<'i>;
+    type QualifiedRule = DeclOrRule<'i>;
+    type Error = anyhow::Error;
+
+    fn parse_prelude<'t>(
+        &mut self,
+        input: &mut cssparser::Parser<'i, 't>,
+    ) -> Result<Self::Prelude, cssparser::ParseError<'i, Self::Error>> {
+        Ok(
+            input.parse_comma_separated_ignoring_errors::<_, _, Self::Error>(|parser| {
+                parser.expect_delim('.')?;
+                parser
+                    .expect_ident_cloned()
+                    .map(|class| Selector::Class(class.clone()))
+                    .map_err(Into::into)
+            }),
+        )
+    }
+
+    fn parse_block<'t>(
+        &mut self,
+        prelude: Self::Prelude,
+        _start: &cssparser::ParserState,
+        input: &mut cssparser::Parser<'i, 't>,
+    ) -> Result<Self::QualifiedRule, cssparser::ParseError<'i, Self::Error>> {
+        let mut parser: Self = *self;
+        let decls = cssparser::RuleBodyParser::new(input, &mut parser)
+            .flat_map(|res| match res {
+                Ok(DeclOrRule::Decl(prop, val)) => Some((prop, val)),
+                Ok(DeclOrRule::Rule(..)) => None,
+                Err((err, css)) => {
+                    self.warn_invalid_css(err, css);
+                    None
+                }
+            })
+            .collect();
+        Ok(DeclOrRule::Rule(prelude, decls))
+    }
+}
+
+impl<'i> cssparser::RuleBodyItemParser<'i, DeclOrRule<'i>, anyhow::Error> for &Parser<'_> {
+    fn parse_declarations(&self) -> bool {
+        true
+    }
+
+    fn parse_qualified(&self) -> bool {
+        false
+    }
+}
+
+impl<'i> cssparser::DeclarationParser<'i> for &Parser<'_> {
+    type Declaration = DeclOrRule<'i>;
+    type Error = anyhow::Error;
+
+    fn parse_value<'t>(
+        &mut self,
+        name: CowRcStr<'i>,
+        input: &mut cssparser::Parser<'i, 't>,
+    ) -> Result<Self::Declaration, cssparser::ParseError<'i, Self::Error>> {
+        input.skip_whitespace();
+        let start = input.position();
+        loop {
+            match input.next() {
+                Ok(_) => {}
+                Err(err) if err.kind == cssparser::BasicParseErrorKind::EndOfInput => break,
+                Err(err) => return Err(err.into()),
+            }
+        }
+        Ok(DeclOrRule::Decl(name, input.slice_from(start)))
+    }
+}
+
+/// Disregard [at-rules](https://developer.mozilla.org/en-US/docs/Web/CSS/At-rule)
+impl<'i> cssparser::AtRuleParser<'i> for &Parser<'_> {
+    type Prelude = Selectors<'i>;
+    type AtRule = DeclOrRule<'i>;
+    type Error = anyhow::Error;
+}

--- a/src/pandoc/profile.rs
+++ b/src/pandoc/profile.rs
@@ -44,9 +44,37 @@ impl Profile {
             OutputFormat::Latex {
                 packages: Default::default(),
             }
+        } else if self.includes_raw_html() {
+            OutputFormat::HtmlLike
         } else {
             OutputFormat::Other
         }
+    }
+
+    /// Formats for which raw HTML is passed through instead of being suppressed.
+    /// See <https://pandoc.org/MANUAL.html#extension-raw_html>
+    #[allow(unused_parens)]
+    fn includes_raw_html(&self) -> bool {
+        let extension = || {
+            (self.output_file)
+                .extension()
+                .and_then(|extension| extension.to_str())
+        };
+        matches!(
+            self.to.as_deref(),
+            Some(
+                ("html" | "html4" | "html5")
+                    | "s5"
+                    | ("slidy" | "slideous")
+                    | "dzslides"
+                    | ("epub" | "epub2" | "epub3")
+                    | "org"
+                    | "textile"
+            )
+        ) || matches!(
+            extension(),
+            Some("html" | "htm" | "xhtml" | "epub" | "md" | "markdown" | "org" | "textile")
+        )
     }
 
     /// Determines whether the profile uses LaTeX, either by outputting it directory or rendering it to PDF.


### PR DESCRIPTION
Parses `<img>` tags from raw HTML and converts them to Markdown image tags that Pandoc will process in non-HTML output formats. Also supports basic image styling from `width`/`height`/`style` attributes and CSS stylesheets since the Rust book relies on this.