### PR TITLE
fix: set document metadata for all output formats

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1415,6 +1415,13 @@ outside divs
     #[test]
     fn raw_opts() {
         let cfg = r#"
+[book]
+title = "Example book"
+authors = ["John Doe", "Jane Doe"]
+description = "The example book covers examples."
+language = "en"
+text-direction = "ltr"
+
 [output.pandoc.profile.test]
 output-file = "/dev/null"
 to = "markdown"
@@ -1462,6 +1469,9 @@ colorlinks = false
         │         "colorlinks": Boolean(
         │             false,
         │         ),
+        │         "dir": String(
+        │             "ltr",
+        │         ),
         │         "header-includes": Array(
         │             [
         │                 String(
@@ -1479,7 +1489,24 @@ colorlinks = false
         │             "en",
         │         ),
         │     },
-        │     metadata: {},
+        │     metadata: {
+        │         "author": Array(
+        │             [
+        │                 String(
+        │                     "John Doe",
+        │                 ),
+        │                 String(
+        │                     "Jane Doe",
+        │                 ),
+        │             ],
+        │         ),
+        │         "description": String(
+        │             "The example book covers examples.",
+        │         ),
+        │         "title": String(
+        │             "Example book",
+        │         ),
+        │     },
         │     rest: {
         │         "fail-if-warnings": Boolean(
         │             false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1393,7 +1393,7 @@ outside divs
         let diff = similar::TextDiff::from_lines(&default.to_string(), &with_overrides.to_string())
             .unified_diff()
             .to_string();
-        insta::assert_snapshot!(diff, @r###"
+        insta::assert_snapshot!(diff, @r##"
         @@ -10,7 +10,7 @@
          │     pdf_engine: None,
          │     standalone: false,
@@ -1403,13 +1403,13 @@ outside divs
          │     ),
          │     to: None,
          │     table_of_contents: true,
-        @@ -19,4 +19,4 @@
+        @@ -24,4 +24,4 @@
          │ }    
          │  INFO mdbook_pandoc::pandoc::renderer: Wrote output to book/markdown/book.md    
          ├─ markdown/book.md
         -│ # Chapter {#book__markdown__src__chaptermd__chapter}
         +│ # Chapter
-        "###);
+        "##);
     }
 
     #[test]
@@ -1439,7 +1439,7 @@ colorlinks = false
             .init()
             .mdbook_config(mdbook::Config::from_str(cfg).unwrap())
             .build();
-        insta::assert_snapshot!(output, @r###"
+        insta::assert_snapshot!(output, @r#"
         ├─ log output
         │ DEBUG mdbook::book: Running the index preprocessor.    
         │ DEBUG mdbook::book: Running the links preprocessor.    
@@ -1475,7 +1475,11 @@ colorlinks = false
         │         "indent": Boolean(
         │             true,
         │         ),
+        │         "lang": String(
+        │             "en",
+        │         ),
         │     },
+        │     metadata: {},
         │     rest: {
         │         "fail-if-warnings": Boolean(
         │             false,
@@ -1496,7 +1500,7 @@ colorlinks = false
         │     },
         │ }    
         │  INFO mdbook_pandoc::pandoc::renderer: Wrote output to /dev/null    
-        "###)
+        "#)
     }
 
     #[test]

--- a/src/pandoc/profile.rs
+++ b/src/pandoc/profile.rs
@@ -23,6 +23,8 @@ pub struct Profile {
     pub table_of_contents: bool,
     #[serde(default)]
     pub variables: BTreeMap<String, toml::Value>,
+    #[serde(default)]
+    pub metadata: BTreeMap<String, toml::Value>,
     #[serde(flatten)]
     pub rest: BTreeMap<String, toml::Value>,
 }

--- a/src/pandoc/renderer.rs
+++ b/src/pandoc/renderer.rs
@@ -129,27 +129,36 @@ impl Renderer {
             format
         });
 
+        let mut default_metadata = vec![];
+        if let Some(title) = ctx.mdbook_cfg.book.title.as_deref() {
+            default_metadata.push(("title", title.into()));
+        }
+        if let Some(description) = ctx.mdbook_cfg.book.description.as_deref() {
+            default_metadata.push(("description", description.into()));
+        }
+        if !ctx.mdbook_cfg.book.authors.is_empty() {
+            default_metadata.push(("author", ctx.mdbook_cfg.book.authors.clone().into()));
+        }
+        for (key, val) in default_metadata {
+            if !profile.metadata.contains_key(key) {
+                profile.metadata.insert(key.into(), val);
+            }
+        }
+
         let mut default_variables = vec![];
+        if let Some(language) = ctx.mdbook_cfg.book.language.as_deref() {
+            default_variables.push(("lang", language.into()));
+        }
+        if let Some(text_direction) = ctx.mdbook_cfg.book.text_direction {
+            let dir = match text_direction {
+                mdbook::config::TextDirection::LeftToRight => "ltr",
+                mdbook::config::TextDirection::RightToLeft => "rtl",
+            };
+            default_variables.push(("dir", dir.into()));
+        }
         match ctx.output {
             OutputFormat::Latex { .. } => {
                 default_variables.push(("documentclass", "report".into()));
-                if let Some(title) = ctx.mdbook_cfg.book.title.as_deref() {
-                    default_variables.push(("title", title.into()));
-                }
-                if let Some(description) = ctx.mdbook_cfg.book.description.as_deref() {
-                    default_variables.push(("description", description.into()));
-                }
-                default_variables.push(("author", ctx.mdbook_cfg.book.authors.clone().into()));
-                if let Some(language) = ctx.mdbook_cfg.book.language.as_deref() {
-                    default_variables.push(("lang", language.into()));
-                }
-                if let Some(text_direction) = ctx.mdbook_cfg.book.text_direction {
-                    let dir = match text_direction {
-                        mdbook::config::TextDirection::LeftToRight => "ltr",
-                        mdbook::config::TextDirection::RightToLeft => "rtl",
-                    };
-                    default_variables.push(("dir", dir.into()));
-                }
             }
             OutputFormat::HtmlLike | OutputFormat::Other => {}
         };


### PR DESCRIPTION
Previously, document metadata (title, authors, etc.) was only set for LaTeX documents. This change sets this metadata for all output formats, and properly sets some of the variables as [`metadata` variables](https://pandoc.org/MANUAL.html#metadata-variables) instead of [regular `variables`](https://pandoc.org/MANUAL.html#language-variables).