### PR TITLE
feat: support block quote tags e.g. [!NOTE]

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ A subset of the available options are described below:
 [output.pandoc]
 hosted-html = "https://doc.rust-lang.org/book" # URL of a HTML version of the book
 
+[output.pandoc.markdown.extensions] # enable additional Markdown extensions
+gfm = false # enable pulldown-cmark's GitHub Flavored Markdown extensions
+
 [output.pandoc.code]
 # Display hidden lines in code blocks (e.g., lines in Rust blocks prefixed by '#').
 # See https://rust-lang.github.io/mdBook/format/mdbook.html?highlight=hidden#hiding-code-lines
@@ -101,8 +104,26 @@ variable-name = "value"
   - [x] [Tables](https://rust-lang.github.io/mdBook/format/markdown.html#tables)
   - [x] [Task Lists](https://rust-lang.github.io/mdBook/format/markdown.html#task-lists) (e.g. `- [x] Complete task`)
   - [x] [Heading Attributes](https://rust-lang.github.io/mdBook/format/markdown.html#heading-attributes) (e.g. `# Heading { #custom-heading }`)
+
+- [ ] `pulldown-cmark` Markdown extensions not yet enabled by mdBook.
+
+  These extensions are disabled by default for consistency with mdBook and must be explicitly enabled.
+  
+  - [x] [Blockquote tags](https://docs.rs/pulldown-cmark/0.13.0/pulldown_cmark/struct.Options.html#associatedconstant.ENABLE_GFM)
+    (Enable by setting `output.pandoc.markdown.extensions.gfm` to `true`)
+
+  - [ ] [Math](https://docs.rs/pulldown-cmark/0.13.0/pulldown_cmark/struct.Options.html#associatedconstant.ENABLE_MATH)
+
+  - [ ] [Definition Lists](https://docs.rs/pulldown-cmark/0.13.0/pulldown_cmark/struct.Options.html#associatedconstant.ENABLE_DEFINITION_LIST)
+
+  - [ ] [Superscript](https://docs.rs/pulldown-cmark/0.13.0/pulldown_cmark/struct.Options.html#associatedconstant.ENABLE_SUPERSCRIPT)
+
+  - [ ] [Subscript](https://docs.rs/pulldown-cmark/0.13.0/pulldown_cmark/struct.Options.html#associatedconstant.ENABLE_SUBSCRIPT)
+
 - [x] Table of contents
+
 - [x] Take [`[output.html.redirect]`](https://rust-lang.github.io/mdBook/format/configuration/renderers.html#outputhtmlredirect) into account when resolving links
+
 - [x] Font Awesome 4 icons (e.g. `<i class="fa fa-github"></i>`) to LaTeX
 
 ### Preprocessing

--- a/src/pandoc/profile.rs
+++ b/src/pandoc/profile.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use super::OutputFormat;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Profile {
     #[serde(default = "defaults::columns")]

--- a/src/preprocess/tree/node.rs
+++ b/src/preprocess/tree/node.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use html5ever::{local_name, namespace_url, ns, tendril::StrTendril, Attribute, QualName};
 use indexmap::IndexMap;
-use pulldown_cmark::{Alignment, CodeBlockKind, CowStr, HeadingLevel, LinkType};
+use pulldown_cmark::{Alignment, BlockQuoteKind, CodeBlockKind, CowStr, HeadingLevel, LinkType};
 
 use crate::html;
 
@@ -52,7 +52,7 @@ pub enum MdElement<'a> {
         classes: Vec<CowStr<'a>>,
         attrs: Vec<(CowStr<'a>, Option<CowStr<'a>>)>,
     },
-    BlockQuote,
+    BlockQuote(Option<BlockQuoteKind>),
     InlineCode(CowStr<'a>),
     CodeBlock(CodeBlockKind<'a>),
     List(Option<u64>),
@@ -218,7 +218,7 @@ impl MdElement<'_> {
                     HeadingLevel::H6 => H6,
                 }
             }
-            MdElement::BlockQuote => {
+            MdElement::BlockQuote(_) => {
                 const BLOCKQUOTE: &QualName = &html::name!(html "blockquote");
                 BLOCKQUOTE
             }

--- a/src/tests/alerts.rs
+++ b/src/tests/alerts.rs
@@ -1,0 +1,54 @@
+use indoc::indoc;
+
+use super::{Chapter, Config, MDBook};
+
+#[test]
+fn alerts() {
+    let diff = |source: &str, mut config: Config| {
+        let chapter = Chapter::new("", source, "chapter.md");
+        let without = MDBook::init()
+            .chapter(chapter.clone())
+            .config(config.clone())
+            .build();
+        let with = MDBook::init()
+            .chapter(chapter)
+            .config({
+                config.markdown.extensions.gfm = true;
+                config
+            })
+            .build();
+        similar::TextDiff::from_lines(&without.to_string(), &with.to_string())
+            .unified_diff()
+            .to_string()
+    };
+    let alert = indoc! {"
+        > [!NOTE]  
+        > Highlights information that users should take into account, even when skimming.
+    "};
+    let latex = diff(alert, Config::latex());
+    insta::assert_snapshot!(latex, @r#"
+    @@ -3,9 +3,8 @@
+     │  INFO mdbook_pandoc::pandoc::renderer: Running pandoc    
+     │  INFO mdbook_pandoc::pandoc::renderer: Wrote output to book/latex/output.tex    
+     ├─ latex/output.tex
+    -│ \begin{quote}
+    -│ {[}!NOTE{]}\\
+    +│ Note
+    +│ 
+     │ Highlights information that users should take into account, even when skimming.
+    -│ \end{quote}
+     ├─ latex/src/chapter.md
+    -│ [BlockQuote [Para [Str "[", Str "!NOTE", Str "]", LineBreak, Str "Highlights information that users should take into account, even when skimming."]]]
+    +│ [Div ("", ["note"], []) [Div ("", ["title"], []) [Para [Str "Note"]], Para [Str "Highlights information that users should take into account, even when skimming."]]]
+    "#);
+    let markdown = diff(alert, Config::markdown());
+    insta::assert_snapshot!(markdown, @r"
+    @@ -3,5 +3,5 @@
+     │  INFO mdbook_pandoc::pandoc::renderer: Running pandoc    
+     │  INFO mdbook_pandoc::pandoc::renderer: Wrote output to book/markdown/book.md    
+     ├─ markdown/book.md
+    -│ > \[!NOTE\]  
+    +│ > [!NOTE]
+     │ > Highlights information that users should take into account, even when skimming.
+    ");
+}

--- a/src/tests/html.rs
+++ b/src/tests/html.rs
@@ -19,26 +19,30 @@ fn html_comments() {
 }
 
 #[test]
-fn nested_html_block() {
+fn noncontiguous_html() {
+    // HTML comment is noncontiguous in the source because it is nested in a block quote.
+    // Parsing should handle this sanely.
     let s = indoc! {"
         > <!-- hello
         >
         > world -->
     "};
     let output = MDBook::init()
-        .config(Config::markdown())
+        .config(Config::pandoc())
         .chapter(Chapter::new("", s, "chapter.md"))
         .build();
-    insta::assert_snapshot!(output, @r"
+    insta::assert_snapshot!(output, @r#"
     ├─ log output
     │  INFO mdbook::book: Running the pandoc backend    
     │  INFO mdbook_pandoc::pandoc::renderer: Running pandoc    
-    │  INFO mdbook_pandoc::pandoc::renderer: Wrote output to book/markdown/book.md    
-    ├─ markdown/book.md
-    │ > <!-- hello
-    │ >
-    │ > world -->
-    ");
+    │  INFO mdbook_pandoc::pandoc::renderer: Wrote output to book/markdown/pandoc-ir    
+    ├─ markdown/pandoc-ir
+    │ [ BlockQuote
+    │     [ RawBlock (Format "html") "<!-- hello\n\nworld -->"
+    │     , Plain [ Str "\n" ]
+    │     ]
+    │ ]
+    "#);
 }
 
 #[test]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -365,6 +365,7 @@ impl Config {
 
             [profile.markdown]
             output-file = "book.md"
+            to = "commonmark_x"
             standalone = false
         }
         .try_into()
@@ -389,6 +390,7 @@ mod basic;
 mod config;
 mod escaping;
 
+mod alerts;
 mod code;
 mod css;
 mod fonts;


### PR DESCRIPTION
Needs an upgrade to `pulldown-cmark`, so will wait to merge until `mdbook` releases a breaking change (see #115).

Closes #117 although not in a terribly helpful way since it appears Pandoc doesn't do anything with alerts when generating LaTeX:

```
$ echo '> [!NOTE]\n> Highlights information that users should take into account, even when skimming.' | pandoc -f commonmark+alerts -t latex
Note

Highlights information that users should take into account, even when
skimming.
```

Contrast with:
```
$ echo '> Highlights information that users should take into account, even when skimming.' | pandoc -f commonmark+alerts -t latex
\begin{quote}
Highlights information that users should take into account, even when
skimming.
\end{quote}
```