### PR TITLE
change: construct a combined Markdown+HTML tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,17 +288,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_more"
-version = "0.99.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,15 +410,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,15 +417,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "getopts"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -818,6 +789,7 @@ dependencies = [
  "ego-tree",
  "env_logger",
  "html5ever",
+ "indexmap",
  "insta",
  "log",
  "mdbook",
@@ -826,7 +798,6 @@ dependencies = [
  "pulldown-cmark",
  "regex",
  "replace_with",
- "scraper",
  "semver",
  "serde",
  "serde_yaml",
@@ -1277,40 +1248,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "scraper"
-version = "0.22.0"
-source = "git+https://github.com/rust-scraper/scraper?rev=1896e4f2c57438b5d42aade714d2b8f3019e983f#1896e4f2c57438b5d42aade714d2b8f3019e983f"
-dependencies = [
- "cssparser",
- "ego-tree",
- "getopts",
- "html5ever",
- "indexmap",
- "precomputed-hash",
- "selectors",
- "tendril",
-]
-
-[[package]]
-name = "selectors"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd568a4c9bb598e291a08244a5c1f5a8a6650bee243b5b0f8dbb3d9cc1d87fe8"
-dependencies = [
- "bitflags",
- "cssparser",
- "derive_more",
- "fxhash",
- "log",
- "new_debug_unreachable",
- "phf",
- "phf_codegen",
- "precomputed-hash",
- "servo_arc",
- "smallvec",
-]
-
-[[package]]
 name = "semver"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1368,15 +1305,6 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
-]
-
-[[package]]
-name = "servo_arc"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae65c4249478a2647db249fb43e23cec56a2c8974a427e7bd8cb5a1d0964921a"
-dependencies = [
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -1704,12 +1632,6 @@ name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,13 @@ anyhow = "1.0.47"
 cssparser = "0.34.0"
 env_logger = "0.11.0"
 html5ever = "0.29.0"
+indexmap = "2.7.0"
 log = "0.4.0"
 mdbook = { version = "0.4.35", default-features = false }
 normpath = "1.0.0"
 once_cell = "1.0.0"
 pulldown-cmark = { version = "0.10.0", default-features = false }
 regex = "1.5.5"
-scraper = { git = "https://github.com/rust-scraper/scraper", rev = "1896e4f2c57438b5d42aade714d2b8f3019e983f", features = ["deterministic"] }
 ego-tree = "0.10.0"
 replace_with = "0.1.7"
 semver = "1.0.0"

--- a/src/html.rs
+++ b/src/html.rs
@@ -1,42 +1,24 @@
-use std::cell::Cell;
+use crate::preprocess;
 
-use html5ever::{interface::TreeSink, namespace_url, ns, LocalName, QualName};
+pub type Parser<'book> = html5ever::Parser<preprocess::tree::HtmlTreeSink<'book>>;
 
-pub type NodeId = <scraper::HtmlTreeSink as TreeSink>::Handle;
-pub type Parser = html5ever::Parser<scraper::HtmlTreeSink>;
-
-pub fn name(local: LocalName) -> QualName {
-    QualName::new(None, ns!(), local)
-}
-
-/// Determines the HTML element to which child events should be appended based on the state of the parser.
-pub fn most_recently_created_open_element(parser: &Parser) -> NodeId {
-    struct Tracer<'a> {
-        html: &'a scraper::Html,
-        prev: Cell<Option<NodeId>>,
-        next: Cell<Option<NodeId>>,
-    }
-
-    impl html5ever::interface::Tracer for Tracer<'_> {
-        type Handle = NodeId;
-
-        fn trace_handle(&self, handle: &Self::Handle) {
-            if let Some(node) = self.html.tree.get(*handle) {
-                if node.value().is_element() {
-                    self.prev.swap(&self.next);
-                    self.next.set(Some(*handle))
-                }
-            }
+#[macro_export]
+macro_rules! html_name {
+    (html $name:tt) => {{
+        use html5ever::namespace_url;
+        html5ever::QualName {
+            prefix: None,
+            ns: html5ever::ns!(html),
+            local: html5ever::local_name!($name),
         }
-    }
-
-    let sink = &parser.tokenizer.sink;
-    let html = sink.sink.0.borrow();
-    let tracer = Tracer {
-        html: &html,
-        prev: Default::default(),
-        next: Default::default(),
-    };
-    sink.trace_handles(&tracer);
-    tracer.prev.into_inner().unwrap()
+    }};
+    ($name:tt) => {{
+        use html5ever::namespace_url;
+        html5ever::QualName {
+            prefix: None,
+            ns: html5ever::ns!(),
+            local: html5ever::local_name!($name),
+        }
+    }};
 }
+pub use crate::html_name as name;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1243,6 +1243,44 @@ some text here
     }
 
     #[test]
+    fn implicitly_closed_tags() {
+        let book = MDBook::init()
+            .config(Config::latex())
+            .chapter(Chapter::new(
+                "",
+                r#"
+- before
+- [Box<T>](#foo)
+- after
+
+# Foo
+                "#,
+                "chapter.md",
+            ))
+            .build();
+        insta::assert_snapshot!(book, @r##"
+        ├─ log output
+        │  INFO mdbook::book: Running the pandoc backend    
+        │  INFO mdbook_pandoc::pandoc::renderer: Running pandoc    
+        │  INFO mdbook_pandoc::pandoc::renderer: Wrote output to book/latex/output.tex    
+        ├─ latex/output.tex
+        │ \begin{itemize}
+        │ \tightlist
+        │ \item
+        │   before
+        │ \item
+        │   \hyperref[book__latex__src__chapter.md__foo]{Box}
+        │ \item
+        │   after
+        │ \end{itemize}
+        │ 
+        │ \chapter{Foo}\label{book__latex__src__chapter.md__foo}
+        ├─ latex/src/chapter.md
+        │ [BulletList [[Plain [Str "before"]], [Plain [Link ("", [], []) [Str "Box", RawInline (Format "html") "<t>", RawInline (Format "html") "</t>"] ("#foo", "")]], [Plain [Str "after"]]], Header 1 ("foo", [], []) [Str "Foo"]]
+        "##);
+    }
+
+    #[test]
     fn rust_reference_regression_nested_elements() {
         let book = MDBook::init()
             .config(Config::latex())
@@ -1411,11 +1449,9 @@ some text here
 text
 
 </summary>
-<p>
 
 more **markdown**
 
-</p>
 </details>
 
 outside divs
@@ -1447,14 +1483,8 @@ outside divs
         │         , Para [ Str "text" ]
         │         ]
         │     , RawBlock (Format "html") "</summary>"
-        │     , Plain [ Str "\n" , RawInline (Format "html") "<p>" ]
-        │     , Div
-        │         ( "" , [] , [] )
-        │         [ Plain [ Str "\n" ]
-        │         , Para [ Str "more " , Strong [ Str "markdown" ] ]
-        │         ]
-        │     , RawBlock (Format "html") "</p>"
         │     , Plain [ Str "\n" ]
+        │     , Para [ Str "more " , Strong [ Str "markdown" ] ]
         │     ]
         │ , RawBlock (Format "html") "</details>"
         │ , Plain [ Str "\n" ]

--- a/src/preprocess/tree/node.rs
+++ b/src/preprocess/tree/node.rs
@@ -1,0 +1,289 @@
+use std::fmt;
+
+use html5ever::{local_name, namespace_url, ns, tendril::StrTendril, Attribute, QualName};
+use indexmap::IndexMap;
+use pulldown_cmark::{Alignment, CodeBlockKind, CowStr, HeadingLevel, LinkType};
+
+use crate::html;
+
+/// A node in the tree.
+pub enum Node<'book> {
+    /// The document root.
+    Document,
+
+    /// An HTML comment.
+    HtmlComment(StrTendril),
+
+    /// Text in raw HTML.
+    HtmlText(StrTendril),
+
+    /// An element.
+    Element(Element<'book>),
+}
+
+#[derive(Clone)]
+pub struct Attributes {
+    pub id: Option<StrTendril>,
+    pub classes: StrTendril,
+    pub rest: IndexMap<QualName, StrTendril>,
+}
+
+pub enum Element<'book> {
+    Html(HtmlElement),
+    Markdown(MdElement<'book>),
+}
+
+/// An HTML element.
+pub struct HtmlElement {
+    /// The element name.
+    pub name: QualName,
+    /// The element attributes.
+    pub attrs: Attributes,
+}
+
+#[derive(Debug)]
+pub enum MdElement<'a> {
+    Paragraph,
+    Text(CowStr<'a>),
+    SoftBreak,
+    Heading {
+        level: HeadingLevel,
+        id: Option<CowStr<'a>>,
+        classes: Vec<CowStr<'a>>,
+        attrs: Vec<(CowStr<'a>, Option<CowStr<'a>>)>,
+    },
+    BlockQuote,
+    InlineCode(CowStr<'a>),
+    CodeBlock(CodeBlockKind<'a>),
+    List(Option<u64>),
+    Item,
+    TaskListMarker(bool),
+    FootnoteDefinition,
+    FootnoteReference(CowStr<'a>),
+    Table {
+        alignment: Vec<Alignment>,
+        source: &'a str,
+    },
+    Emphasis,
+    Strong,
+    Strikethrough,
+    Link {
+        dest_url: CowStr<'a>,
+        title: CowStr<'a>,
+    },
+    Image {
+        link_type: LinkType,
+        dest_url: CowStr<'a>,
+        title: CowStr<'a>,
+        id: CowStr<'a>,
+    },
+}
+
+pub trait QualNameExt {
+    /// Is this the name of a [void element](https://developer.mozilla.org/en-US/docs/Glossary/Void_element)?
+    fn is_void_element(&self) -> bool;
+}
+
+impl QualNameExt for QualName {
+    fn is_void_element(&self) -> bool {
+        self.ns == ns!(html)
+            && matches!(
+                self.local,
+                local_name!("area")
+                    | local_name!("base")
+                    | local_name!("basefont")
+                    | local_name!("bgsound")
+                    | local_name!("br")
+                    | local_name!("col")
+                    | local_name!("embed")
+                    | local_name!("frame")
+                    | local_name!("hr")
+                    | local_name!("img")
+                    | local_name!("input")
+                    | local_name!("keygen")
+                    | local_name!("link")
+                    | local_name!("meta")
+                    | local_name!("param")
+                    | local_name!("source")
+                    | local_name!("track")
+                    | local_name!("wbr")
+            )
+    }
+}
+
+impl Element<'_> {
+    pub fn name(&self) -> &QualName {
+        match self {
+            Self::Html(element) => &element.name,
+            Self::Markdown(element) => element.name(),
+        }
+    }
+}
+
+impl MdElement<'_> {
+    pub fn name(&self) -> &QualName {
+        match self {
+            MdElement::Paragraph => {
+                const P: &QualName = &html::name!(html "p");
+                P
+            }
+            MdElement::Text(_) => {
+                const SPAN: &QualName = &html::name!(html "span");
+                SPAN
+            }
+            MdElement::SoftBreak => {
+                const BR: &QualName = &html::name!(html "br");
+                BR
+            }
+            MdElement::List(None) => {
+                const UL: &QualName = &html::name!(html "ul");
+                UL
+            }
+            MdElement::List(Some(_)) => {
+                const OL: &QualName = &html::name!(html "ol");
+                OL
+            }
+            MdElement::Item => {
+                const LI: &QualName = &html::name!(html "li");
+                LI
+            }
+            MdElement::Table { .. } => {
+                const TABLE: &QualName = &html::name!(html "table");
+                TABLE
+            }
+            MdElement::Link { .. } => {
+                const A: &QualName = &html::name!(html "a");
+                A
+            }
+            MdElement::FootnoteDefinition => {
+                // Pretend footnote definitions are <span>s to fit them
+                // into the HTML parser's view of the world.
+                const SPAN: &QualName = &html::name!(html "span");
+                SPAN
+            }
+            MdElement::FootnoteReference(_) => {
+                const SUP: &QualName = &html::name!(html "sup");
+                SUP
+            }
+            MdElement::Heading { level, .. } => {
+                const H1: &QualName = &html::name!(html "h1");
+                const H2: &QualName = &html::name!(html "h2");
+                const H3: &QualName = &html::name!(html "h3");
+                const H4: &QualName = &html::name!(html "h4");
+                const H5: &QualName = &html::name!(html "h5");
+                const H6: &QualName = &html::name!(html "h6");
+                match level {
+                    HeadingLevel::H1 => H1,
+                    HeadingLevel::H2 => H2,
+                    HeadingLevel::H3 => H3,
+                    HeadingLevel::H4 => H4,
+                    HeadingLevel::H5 => H5,
+                    HeadingLevel::H6 => H6,
+                }
+            }
+            MdElement::BlockQuote => {
+                const BLOCKQUOTE: &QualName = &html::name!(html "blockquote");
+                BLOCKQUOTE
+            }
+            MdElement::CodeBlock(_) => {
+                const PRE: &QualName = &html::name!(html "pre");
+                PRE
+            }
+            MdElement::Emphasis => {
+                const EM: &QualName = &html::name!(html "em");
+                EM
+            }
+            MdElement::Strong => {
+                const STRONG: &QualName = &html::name!(html "strong");
+                STRONG
+            }
+            MdElement::Strikethrough => {
+                const S: &QualName = &html::name!(html "s");
+                S
+            }
+            MdElement::Image { .. } => {
+                // <img> is a void element in HTML (can have no children),
+                // but in Markdown the "alt text" *can* contain children.
+                // Therefore, we pretend images are <span>s so the parser
+                // lets us add children.
+                const SPAN: &QualName = &html::name!(html "span");
+                SPAN
+            }
+            MdElement::InlineCode(_) => {
+                const CODE: &QualName = &html::name!(html "code");
+                CODE
+            }
+            MdElement::TaskListMarker(_) => {
+                const INPUT: &QualName = &html::name!(html "input");
+                INPUT
+            }
+        }
+    }
+}
+
+impl HtmlElement {
+    pub fn new(name: QualName, attributes: Vec<Attribute>) -> Self {
+        let mut attrs = Attributes {
+            id: None,
+            classes: StrTendril::new(),
+            rest: IndexMap::with_capacity(attributes.len()),
+        };
+        for attr in attributes {
+            match attr.name.local {
+                local_name!("id") => {
+                    attrs.id = Some(attr.value);
+                }
+                local_name!("class") => {
+                    attrs.classes = attr.value;
+                }
+                _ => {
+                    attrs.rest.insert(attr.name, attr.value);
+                }
+            }
+        }
+        HtmlElement { name, attrs }
+    }
+}
+
+impl Attributes {
+    pub fn iter(&self) -> impl Iterator<Item = (&QualName, &StrTendril)> {
+        const ID: &QualName = &html::name!("id");
+        const CLASS: &QualName = &html::name!("class");
+        (self.id.as_ref().map(|id| (ID, id)).into_iter())
+            .chain((!self.classes.is_empty()).then_some((CLASS, &self.classes)))
+            .chain(&self.rest)
+    }
+}
+
+impl fmt::Debug for Node<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Node::Document => write!(f, "Document"),
+            Node::HtmlComment(comment) => write!(f, "<!-- {comment} -->"),
+            Node::HtmlText(text) => write!(f, "Text({text})"),
+            Node::Element(element) => write!(f, "{element:?}"),
+        }
+    }
+}
+
+impl fmt::Debug for Element<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Element::Html(element) => write!(f, "{element:?}"),
+            Element::Markdown(element) => write!(f, "{element:?}"),
+        }
+    }
+}
+
+impl fmt::Debug for HtmlElement {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "<{}", self.name.local)?;
+        if !self.attrs.classes.is_empty() {
+            write!(f, r#" class="{}""#, self.attrs.classes)?;
+        }
+        for (name, value) in &self.attrs.rest {
+            write!(f, r#" {}="{value}""#, name.local)?;
+        }
+        write!(f, ">")
+    }
+}

--- a/src/preprocess/tree/sink.rs
+++ b/src/preprocess/tree/sink.rs
@@ -1,0 +1,212 @@
+use ego_tree::NodeId;
+use html5ever::{
+    local_name,
+    tendril::{format_tendril, StrTendril},
+    tree_builder::{ElementFlags, NodeOrText, QuirksMode, TreeSink},
+    Attribute, QualName,
+};
+use std::{
+    borrow::Cow,
+    cell::{Cell, Ref, RefCell},
+};
+
+use super::{
+    node::{Element, HtmlElement, Node},
+    Tree,
+};
+
+#[derive(Debug)]
+pub struct HtmlTreeSink<'book> {
+    pub tree: RefCell<Tree<'book>>,
+    pub most_recently_created_element: Cell<Option<NodeId>>,
+}
+
+impl HtmlTreeSink<'_> {
+    pub fn new() -> Self {
+        Self {
+            tree: RefCell::new(Tree::new()),
+            most_recently_created_element: Cell::new(None),
+        }
+    }
+}
+
+impl<'book> TreeSink for HtmlTreeSink<'book> {
+    type Handle = NodeId;
+    type Output = Tree<'book>;
+    type ElemName<'a>
+        = Ref<'a, QualName>
+    where
+        Self: 'a;
+
+    fn finish(self) -> Tree<'book> {
+        self.tree.into_inner()
+    }
+
+    fn parse_error(&self, msg: Cow<'static, str>) {
+        self.tree.borrow_mut().errors.push(msg);
+    }
+
+    fn get_document(&self) -> Self::Handle {
+        self.tree.borrow().tree.root().id()
+    }
+
+    fn elem_name<'a>(&'a self, target: &Self::Handle) -> Ref<'a, QualName> {
+        Ref::map(self.tree.borrow(), |this| {
+            let node = this.tree.get(*target).unwrap().value();
+            match node {
+                Node::Element(element) => element.name(),
+                _ => unreachable!(),
+            }
+        })
+    }
+
+    fn create_element(
+        &self,
+        name: QualName,
+        attrs: Vec<Attribute>,
+        _flags: ElementFlags,
+    ) -> Self::Handle {
+        let mut this = self.tree.borrow_mut();
+        let node = this
+            .tree
+            .orphan(Node::Element(Element::Html(HtmlElement::new(name, attrs))));
+        let id = node.id();
+        self.most_recently_created_element.set(Some(id));
+        id
+    }
+
+    fn create_comment(&self, comment: StrTendril) -> Self::Handle {
+        let mut this = self.tree.borrow_mut();
+        this.tree.orphan(Node::HtmlComment(comment)).id()
+    }
+
+    fn create_pi(&self, target: StrTendril, data: StrTendril) -> Self::Handle {
+        let mut this = self.tree.borrow_mut();
+        // https://developer.mozilla.org/en-US/docs/Web/API/ProcessingInstruction
+        // says processing instructions are considered comments in HTML
+        let comment = format_tendril!("<?{target} {data}?>");
+        this.tree.orphan(Node::HtmlComment(comment)).id()
+    }
+
+    fn append(&self, parent: &Self::Handle, child: NodeOrText<Self::Handle>) {
+        let mut this = self.tree.borrow_mut();
+        let mut parent = this.tree.get_mut(*parent).unwrap();
+
+        match child {
+            NodeOrText::AppendNode(id) => {
+                parent.append_id(id);
+            }
+            NodeOrText::AppendText(text) => {
+                if let Some(mut child) = parent.last_child() {
+                    if let Node::HtmlText(t) = child.value() {
+                        t.push_tendril(&text);
+                        return;
+                    }
+                }
+                parent.append(Node::HtmlText(text));
+            }
+        }
+    }
+
+    fn append_based_on_parent_node(
+        &self,
+        element: &Self::Handle,
+        prev_element: &Self::Handle,
+        child: NodeOrText<Self::Handle>,
+    ) {
+        let has_parent = {
+            let this = self.tree.borrow();
+            let element = this.tree.get(*element).unwrap();
+            element.parent().is_some()
+        };
+
+        if has_parent {
+            self.append_before_sibling(element, child)
+        } else {
+            self.append(prev_element, child)
+        }
+    }
+
+    fn append_doctype_to_document(
+        &self,
+        _name: StrTendril,
+        _public_id: StrTendril,
+        _system_id: StrTendril,
+    ) {
+    }
+
+    fn get_template_contents(&self, target: &Self::Handle) -> Self::Handle {
+        let this = self.tree.borrow();
+        let template = this.tree.get(*target).unwrap();
+        template.first_child().unwrap().id()
+    }
+
+    fn same_node(&self, x: &Self::Handle, y: &Self::Handle) -> bool {
+        x == y
+    }
+
+    fn set_quirks_mode(&self, _mode: QuirksMode) {}
+
+    fn append_before_sibling(&self, sibling: &Self::Handle, new_node: NodeOrText<Self::Handle>) {
+        let mut this = self.tree.borrow_mut();
+        let mut sibling = this.tree.get_mut(*sibling).unwrap();
+
+        match new_node {
+            NodeOrText::AppendNode(id) => {
+                sibling.insert_id_before(id);
+            }
+            NodeOrText::AppendText(text) => {
+                if let Some(mut prev) = sibling.prev_sibling() {
+                    if let Node::HtmlText(t) = prev.value() {
+                        t.push_tendril(&text);
+                        return;
+                    }
+                }
+                sibling.insert_before(Node::HtmlText(text));
+            }
+        }
+    }
+
+    fn add_attrs_if_missing(&self, target: &Self::Handle, attributes: Vec<Attribute>) {
+        let mut this = self.tree.borrow_mut();
+        let mut node = this.tree.get_mut(*target).unwrap();
+        let Node::Element(element) = node.value() else {
+            unreachable!()
+        };
+        match element {
+            Element::Markdown(_) => {}
+            Element::Html(element) => {
+                let attrs = &mut element.attrs;
+                for attr in attributes {
+                    match attr.name.local {
+                        local_name!("id") => {
+                            if attrs.id.is_none() {
+                                attrs.id = Some(attr.value);
+                            }
+                        }
+                        local_name!("class") => {
+                            if attrs.classes.is_empty() {
+                                attrs.classes = attr.value;
+                            }
+                        }
+                        _ => {
+                            attrs.rest.entry(attr.name).or_insert(attr.value);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn remove_from_parent(&self, target: &Self::Handle) {
+        let mut this = self.tree.borrow_mut();
+        let mut node = this.tree.get_mut(*target).unwrap();
+        node.detach();
+    }
+
+    fn reparent_children(&self, node: &Self::Handle, new_parent: &Self::Handle) {
+        let mut this = self.tree.borrow_mut();
+        let mut new_parent = this.tree.get_mut(*new_parent).unwrap();
+        new_parent.reparent_from_id_append(*node);
+    }
+}


### PR DESCRIPTION
Parses each Markdown file into a DOM-like tree using a browser-grade HTML parser to ensure that implicit structure present in raw HTML is preserved.