### PR TITLE
fix!: be more selective about div-wrapping

### DIFF
--- a/src/pandoc/native.rs
+++ b/src/pandoc/native.rs
@@ -230,6 +230,13 @@ impl<'serializer, 'book, 'p, W: io::Write> SerializeNested<'_, 'serializer, 'boo
         }
     }
 
+    pub fn is_blocks(&self) -> bool {
+        matches!(
+            self,
+            Self::Blocks(_) | Self::BlocksSerializingInlines { .. }
+        )
+    }
+
     pub fn blocks(&mut self) -> anyhow::Result<&mut SerializeBlocks<'serializer, 'book, 'p, W>> {
         replace_with::replace_with_or_abort_and_return(self, |nested| match nested {
             Self::BlocksSerializingInlines {

--- a/src/preprocess/tree/node.rs
+++ b/src/preprocess/tree/node.rs
@@ -82,6 +82,9 @@ pub enum MdElement<'a> {
 pub trait QualNameExt {
     /// Is this the name of a [void element](https://developer.mozilla.org/en-US/docs/Glossary/Void_element)?
     fn is_void_element(&self) -> bool;
+
+    /// Does this element default to `display: block`?
+    fn is_display_block(&self) -> bool;
 }
 
 impl QualNameExt for QualName {
@@ -107,6 +110,40 @@ impl QualNameExt for QualName {
                     | local_name!("source")
                     | local_name!("track")
                     | local_name!("wbr")
+            )
+    }
+
+    // Taken from https://www.w3schools.com/cssref/css_default_values.php and filtered down to
+    // those that are likely to appear in mdbooks.
+    fn is_display_block(&self) -> bool {
+        self.ns == ns!(html)
+            && matches!(
+                self.local,
+                local_name!("address")
+                    | local_name!("article")
+                    | local_name!("aside")
+                    | local_name!("blockquote")
+                    | local_name!("dd")
+                    | local_name!("details")
+                    | local_name!("div")
+                    | local_name!("dl")
+                    | local_name!("dt")
+                    | local_name!("figcaption")
+                    | local_name!("figure")
+                    | local_name!("h1")
+                    | local_name!("h2")
+                    | local_name!("h3")
+                    | local_name!("h4")
+                    | local_name!("h5")
+                    | local_name!("h6")
+                    | local_name!("hr")
+                    | local_name!("legend")
+                    | local_name!("ol")
+                    | local_name!("p")
+                    | local_name!("pre")
+                    | local_name!("section")
+                    | local_name!("summary")
+                    | local_name!("ul")
             )
     }
 }


### PR DESCRIPTION
When HTML elements remain unclosed at the end of a raw HTML block, we sometimes wrap the contents of the element in a <div> to preserve the implicit structure when converting to e.g. EPUB for which Pandoc breaks documents into sections based on inferred structure.

The old behavior was too aggressive and resulted in unintended line breaks because pandoc has no notion of inline divs. This change refines the heuristic to be more selective.