### PR TITLE
fix: detect cycles in footnote definitions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2177,6 +2177,28 @@ mainfontfallback = [
         "#);
     }
 
+    #[test]
+    fn footnote_cycle() {
+        let output = MDBook::init()
+            .chapter(Chapter::new(
+                "",
+                "[^1]\n\n[^1]: [^2]\n\n[^2]: [^1]",
+                "chapter.md",
+            ))
+            .build();
+        insta::assert_snapshot!(output, @r"
+        ├─ log output
+        │  INFO mdbook::book: Running the pandoc backend    
+        │  WARN mdbook_pandoc::preprocess::tree: Cycle in footnote definitions: 1 => 2 => 1    
+        │  INFO mdbook_pandoc::pandoc::renderer: Running pandoc    
+        │  INFO mdbook_pandoc::pandoc::renderer: Wrote output to book/markdown/book.md    
+        ├─ markdown/book.md
+        │ [^1]
+        │ 
+        │ [^1]: [^2]
+        ");
+    }
+
     static BOOKS: Lazy<PathBuf> = Lazy::new(|| Path::new(env!("CARGO_MANIFEST_DIR")).join("books"));
 
     #[test]

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -849,6 +849,7 @@ impl<'book, 'preprocessor> PreprocessChapter<'book, 'preprocessor> {
         }
         let events = tree.finish();
 
+        log::trace!("Writing Pandoc AST for chapter '{}'", self.chapter.name);
         pandoc::native::Serializer::serialize(writer, self, |blocks| events.emit(blocks))
     }
 
@@ -858,6 +859,7 @@ impl<'book, 'preprocessor> PreprocessChapter<'book, 'preprocessor> {
         range: Range<usize>,
         tree: &mut TreeBuilder<'book>,
     ) -> anyhow::Result<()> {
+        log::trace!("Preprocessing event: {event:?}");
         match event {
             Event::Start(tag) => {
                 let push_element = |this: &mut Self, tree: &mut TreeBuilder<'book>, element| {


### PR DESCRIPTION
Pandoc does not support cyclic footnote definitions so trying to write the AST for one results in infinite recursion and a stack overflow. Adds a check to detect this before the stack overflow and emit a warning.