### PR TITLE
chore: release v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.9.2] - 2025-01-18
+
+### Bug Fixes
+
+- Parse `<noscript>` elements without panicking (#150)
+- Detect cycles in footnote definitions (#151)
+
+
 ## [0.9.1] - 2025-01-17
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,9 +140,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.9"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8293772165d9345bdaaa39b45b2109591e63fe5e6fbc23c6ff930a048aa310b"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "shlex",
 ]
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-pandoc"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mdbook-pandoc"
 description = "A mdbook backend that outsources most of the rendering process to pandoc."
-version = "0.9.1"
+version = "0.9.2"
 rust-version = "1.75.0"
 edition = "2021"
 authors = ["Max Heller <max.a.heller@gmail.com>"]


### PR DESCRIPTION
## 🤖 New release
* `mdbook-pandoc`: 0.9.1 -> 0.9.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.2] - 2025-01-18

### Bug Fixes

- Parse `<noscript>` elements without panicking (#150)
- Detect cycles in footnote definitions (#151)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).