### PR TITLE
chore: release v0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.9.3] - 2025-01-18
+
+### Documentation
+
+- Suggest `cargo install --locked` and fix formatting in README (#157)
+
+### Miscellaneous Tasks
+
+- Unexport accidentally-exported macro (#153)
+
+### Testing
+
+- Clean up multiline strings in tests using `indoc` (#155)
+- Split test suite into sections (#156)
+
+
 ## [0.9.2] - 2025-01-18
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-pandoc"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mdbook-pandoc"
 description = "A mdbook backend that outsources most of the rendering process to pandoc."
-version = "0.9.2"
+version = "0.9.3"
 rust-version = "1.75.0"
 edition = "2021"
 authors = ["Max Heller <max.a.heller@gmail.com>"]


### PR DESCRIPTION
## 🤖 New release
* `mdbook-pandoc`: 0.9.2 -> 0.9.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.3] - 2025-01-18

### Documentation

- Suggest `cargo install --locked` and fix formatting in README (#157)

### Miscellaneous Tasks

- Unexport accidentally-exported macro (#153)

### Testing

- Clean up multiline strings in tests using `indoc` (#155)
- Split test suite into sections (#156)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).