### PR TITLE
change: upgrade `pulldown-cmark` to 0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -659,7 +659,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "opener",
- "pulldown-cmark",
+ "pulldown-cmark 0.10.3",
  "regex",
  "serde",
  "serde_json",
@@ -686,7 +686,7 @@ dependencies = [
  "mdbook",
  "normpath",
  "once_cell",
- "pulldown-cmark",
+ "pulldown-cmark 0.13.0",
  "regex",
  "replace_with",
  "semver",
@@ -949,6 +949,17 @@ dependencies = [
  "bitflags",
  "memchr",
  "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
+dependencies = [
+ "bitflags",
+ "memchr",
  "unicase",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ log = "0.4.0"
 mdbook = { version = "0.4.35", default-features = false }
 normpath = "1.0.0"
 once_cell = "1.0.0"
-pulldown-cmark = { version = "0.10.0", default-features = false }
+pulldown-cmark = { version = "0.13.0", default-features = false }
 regex = "1.5.5"
 ego-tree = "0.10.0"
 replace_with = "0.1.7"

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -229,8 +229,15 @@ impl<'book> Preprocessor<'book> {
         match link_type {
             // Don't try to normalize emails
             Email => return Ok(link),
-            Inline | Reference | ReferenceUnknown | Collapsed | CollapsedUnknown | Shortcut
-            | ShortcutUnknown | Autolink => {}
+            Inline
+            | Reference
+            | ReferenceUnknown
+            | Collapsed
+            | CollapsedUnknown
+            | Shortcut
+            | ShortcutUnknown
+            | Autolink
+            | WikiLink { .. } => {}
         }
 
         // URI scheme definition: https://datatracker.ietf.org/doc/html/rfc3986#section-3.1
@@ -861,7 +868,7 @@ impl<'book, 'preprocessor> PreprocessChapter<'book, 'preprocessor> {
                         push_element(self, tree, MdElement::Link { dest_url, title })
                     }
                     Tag::Paragraph => push_element(self, tree, MdElement::Paragraph),
-                    Tag::BlockQuote => push_element(self, tree, MdElement::BlockQuote),
+                    Tag::BlockQuote(_) => push_element(self, tree, MdElement::BlockQuote),
                     Tag::CodeBlock(kind) => push_element(self, tree, MdElement::CodeBlock(kind)),
                     Tag::Emphasis => push_element(self, tree, MdElement::Emphasis),
                     Tag::Strong => push_element(self, tree, MdElement::Strong),
@@ -891,6 +898,12 @@ impl<'book, 'preprocessor> PreprocessChapter<'book, 'preprocessor> {
                         }
                         return Ok(());
                     }
+                    // Definition list parsing is not enabled
+                    Tag::DefinitionList
+                    | Tag::DefinitionListTitle
+                    | Tag::DefinitionListDefinition => unreachable!(),
+                    // Not enabled
+                    Tag::Superscript | Tag::Subscript => unreachable!(),
                 }?;
                 Ok(())
             }
@@ -958,6 +971,8 @@ impl<'book, 'preprocessor> PreprocessChapter<'book, 'preprocessor> {
                 tree.create_element(MdElement::TaskListMarker(checked))?;
                 Ok(())
             }
+            // Math option is not enabled
+            Event::InlineMath(_) | Event::DisplayMath(_) => unreachable!(),
         }
     }
 


### PR DESCRIPTION
Upgrades `pulldown-cmark` from 0.10.0 to 0.13.0, diverging from mdbook which is stuck on 0.10.0. The new extensions are left disabled, so this shouldn't be a breaking change.