### PR TITLE
feat: support mathematical expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ variable-name = "value"
   - [x] [Blockquote tags](https://docs.rs/pulldown-cmark/0.13.0/pulldown_cmark/struct.Options.html#associatedconstant.ENABLE_GFM)
     (Enable by setting `output.pandoc.markdown.extensions.gfm` to `true`)
 
-  - [ ] [Math](https://docs.rs/pulldown-cmark/0.13.0/pulldown_cmark/struct.Options.html#associatedconstant.ENABLE_MATH)
+  - [x] [Math](https://docs.rs/pulldown-cmark/0.13.0/pulldown_cmark/struct.Options.html#associatedconstant.ENABLE_MATH)
+    (Enable by setting `output.pandoc.markdown.extensions.math` to `true`)
 
   - [ ] [Definition Lists](https://docs.rs/pulldown-cmark/0.13.0/pulldown_cmark/struct.Options.html#associatedconstant.ENABLE_DEFINITION_LIST)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,9 @@ struct MarkdownExtensionConfig {
     /// Enable [`pulldown_cmark::Options::ENABLE_GFM`].
     #[serde(default = "defaults::disabled")]
     pub gfm: bool,
+    /// Enable [`pulldown_cmark::Options::ENABLE_MATH`].
+    #[serde(default = "defaults::disabled")]
+    pub math: bool,
 }
 
 /// Configuration for tweaking how code blocks are rendered.

--- a/src/pandoc/native.rs
+++ b/src/pandoc/native.rs
@@ -15,6 +15,11 @@ use super::OutputFormat;
 
 pub mod escape;
 
+pub enum MathType {
+    Display,
+    Inline,
+}
+
 /// Alignment of a table column.
 pub enum Alignment {
     Default,
@@ -589,6 +594,22 @@ impl<'book, 'p, W: io::Write> SerializeInline<'_, 'book, 'p, W> {
     /// Hard line break
     pub fn serialize_line_break(self) -> anyhow::Result<()> {
         write!(self.serializer.unescaped(), "LineBreak")?;
+        Ok(())
+    }
+
+    /// TeX math (literal)
+    pub fn serialize_math(self, ty: MathType, math: &str) -> anyhow::Result<()> {
+        write!(self.serializer.unescaped(), "Math ")?;
+        let ty = match ty {
+            MathType::Display => "DisplayMath",
+            MathType::Inline => "InlineMath",
+        };
+        write!(self.serializer.unescaped(), "{ty}")?;
+        write!(
+            self.serializer.unescaped(),
+            r#" "{}""#,
+            math.escape_quotes_verbatim()
+        )?;
         Ok(())
     }
 

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -627,9 +627,12 @@ impl<'book> Parser<'book> {
 
         let options = {
             let mut options = PARSER_OPTIONS;
-            let MarkdownExtensionConfig { gfm } = extensions;
+            let MarkdownExtensionConfig { gfm, math } = extensions;
             if gfm {
                 options |= Options::ENABLE_GFM;
+            }
+            if math {
+                options |= Options::ENABLE_MATH;
             }
             options
         };
@@ -986,8 +989,16 @@ impl<'book, 'preprocessor> PreprocessChapter<'book, 'preprocessor> {
                 tree.create_element(MdElement::TaskListMarker(checked))?;
                 Ok(())
             }
-            // Math option is not enabled
-            Event::InlineMath(_) | Event::DisplayMath(_) => unreachable!(),
+            Event::InlineMath(math) => {
+                tree.create_element(MdElement::InlineMath(math))?;
+                tree.process_html("</span>".into());
+                Ok(())
+            }
+            Event::DisplayMath(math) => {
+                tree.create_element(MdElement::DisplayMath(math))?;
+                tree.process_html("</span>".into());
+                Ok(())
+            }
         }
     }
 

--- a/src/preprocess/tree.rs
+++ b/src/preprocess/tree.rs
@@ -507,6 +507,16 @@ impl<'book> Emitter<'book> {
                         })
                     })
                 }),
+                MdElement::InlineMath(math) => serializer.serialize_inlines(|inlines| {
+                    inlines
+                        .serialize_element()?
+                        .serialize_math(pandoc::native::MathType::Inline, math)
+                }),
+                MdElement::DisplayMath(math) => serializer.serialize_inlines(|inlines| {
+                    inlines
+                        .serialize_element()?
+                        .serialize_math(pandoc::native::MathType::Display, math)
+                }),
                 MdElement::Image {
                     link_type,
                     dest_url,

--- a/src/preprocess/tree/node.rs
+++ b/src/preprocess/tree/node.rs
@@ -67,6 +67,8 @@ pub enum MdElement<'a> {
     Emphasis,
     Strong,
     Strikethrough,
+    InlineMath(CowStr<'a>),
+    DisplayMath(CowStr<'a>),
     Link {
         dest_url: CowStr<'a>,
         title: CowStr<'a>,
@@ -253,6 +255,10 @@ impl MdElement<'_> {
             MdElement::TaskListMarker(_) => {
                 const INPUT: &QualName = &html::name!(html "input");
                 INPUT
+            }
+            MdElement::InlineMath(_) | MdElement::DisplayMath(_) => {
+                const SPAN: &QualName = &html::name!(html "span");
+                SPAN
             }
         }
     }

--- a/src/tests/math.rs
+++ b/src/tests/math.rs
@@ -1,0 +1,44 @@
+use indoc::indoc;
+
+use super::{Chapter, Config, MDBook};
+
+#[test]
+fn math() {
+    let diff = |source: &str, mut config: Config| {
+        let chapter = Chapter::new("", source, "chapter.md");
+        let without = MDBook::init()
+            .chapter(chapter.clone())
+            .config(config.clone())
+            .build();
+        let with = MDBook::init()
+            .chapter(chapter)
+            .config({
+                config.markdown.extensions.math = true;
+                config
+            })
+            .build();
+        similar::TextDiff::from_lines(&without.to_string(), &with.to_string())
+            .unified_diff()
+            .to_string()
+    };
+    let math = indoc! {"
+        $$I(x)=I_0e^{-ax}\\\\another line$$
+
+        inline $a^b$ math
+    "};
+    let latex = diff(math, Config::latex());
+    insta::assert_snapshot!(latex, @r#"
+    @@ -3,8 +3,8 @@
+     │  INFO mdbook_pandoc::pandoc::renderer: Running pandoc    
+     │  INFO mdbook_pandoc::pandoc::renderer: Wrote output to book/latex/output.tex    
+     ├─ latex/output.tex
+    -│ \$\$I(x)=I\_0e\^{}\{-ax\}\textbackslash another line\$\$
+    +│ \[I(x)=I_0e^{-ax}\\another line\]
+     │ 
+    -│ inline \$a\^{}b\$ math
+    +│ inline \(a^b\) math
+     ├─ latex/src/chapter.md
+    -│ [Para [Str "$$I(x)=I_0e^{-ax}", Str "\\another line$$"], Para [Str "inline $a^b$ math"]]
+    +│ [Para [Math DisplayMath "I(x)=I_0e^{-ax}\\\\another line"], Para [Str "inline ", Math InlineMath "a^b", Str " math"]]
+    "#);
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -399,6 +399,7 @@ mod headings;
 mod html;
 mod images;
 mod links;
+mod math;
 mod redirects;
 mod tables;
 


### PR DESCRIPTION
Adds support for inline and block-level mathematical expressions using `$a^b$` and `$$a^b$$`. For consistency with mdbook, this feature is disabled by default and must be explicitly enabled by enabling the `output.pandoc.markdown.extensions.math` option.