### PR TITLE
feat: support definition lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ hosted-html = "https://doc.rust-lang.org/book" # URL of a HTML version of the bo
 [output.pandoc.markdown.extensions] # enable additional Markdown extensions
 gfm = false # enable pulldown-cmark's GitHub Flavored Markdown extensions
 math = false # parse inline ($a^b$) and display ($$a^b$$) math
+definition-lists = false # parse definition lists
 
 [output.pandoc.code]
 # Display hidden lines in code blocks (e.g., lines in Rust blocks prefixed by '#').
@@ -116,7 +117,8 @@ variable-name = "value"
   - [x] [Math](https://docs.rs/pulldown-cmark/0.13.0/pulldown_cmark/struct.Options.html#associatedconstant.ENABLE_MATH)
     (Enable by setting `output.pandoc.markdown.extensions.math` to `true`)
 
-  - [ ] [Definition Lists](https://docs.rs/pulldown-cmark/0.13.0/pulldown_cmark/struct.Options.html#associatedconstant.ENABLE_DEFINITION_LIST)
+  - [x] [Definition Lists](https://docs.rs/pulldown-cmark/0.13.0/pulldown_cmark/struct.Options.html#associatedconstant.ENABLE_DEFINITION_LIST)
+    (Enable by setting `output.pandoc.markdown.extensions.definition-lists` to `true`)
 
   - [ ] [Superscript](https://docs.rs/pulldown-cmark/0.13.0/pulldown_cmark/struct.Options.html#associatedconstant.ENABLE_SUPERSCRIPT)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,9 @@ struct MarkdownExtensionConfig {
     /// Enable [`pulldown_cmark::Options::ENABLE_MATH`].
     #[serde(default = "defaults::disabled")]
     pub math: bool,
+    /// Enable [`pulldown_cmark::Options::ENABLE_DEFINITION_LIST`].
+    #[serde(default = "defaults::disabled")]
+    pub definition_lists: bool,
 }
 
 /// Configuration for tweaking how code blocks are rendered.

--- a/src/preprocess/tree/node.rs
+++ b/src/preprocess/tree/node.rs
@@ -289,6 +289,10 @@ impl HtmlElement {
 }
 
 impl Attributes {
+    pub fn is_empty(&self) -> bool {
+        self.id.is_none() && self.classes.is_empty() && self.rest.is_empty()
+    }
+
     pub fn iter(&self) -> impl Iterator<Item = (&QualName, &StrTendril)> {
         const ID: &QualName = &html::name!("id");
         const CLASS: &QualName = &html::name!("class");
@@ -303,7 +307,7 @@ impl fmt::Debug for Node<'_> {
         match self {
             Node::Document => write!(f, "Document"),
             Node::HtmlComment(comment) => write!(f, "<!-- {comment} -->"),
-            Node::HtmlText(text) => write!(f, "Text({text})"),
+            Node::HtmlText(text) => write!(f, "HtmlText({:?})", text.as_ref()),
             Node::Element(element) => write!(f, "{element:?}"),
         }
     }

--- a/src/tests/definition_lists.rs
+++ b/src/tests/definition_lists.rs
@@ -1,0 +1,86 @@
+use indoc::indoc;
+
+use super::{Chapter, Config, MDBook};
+
+#[test]
+fn basic() {
+    let diff = |source: &str, mut config: Config| {
+        let chapter = Chapter::new("", source, "chapter.md");
+        let without = MDBook::init()
+            .chapter(chapter.clone())
+            .config(config.clone())
+            .build();
+        let with = MDBook::init()
+            .chapter(chapter)
+            .config({
+                config.markdown.extensions.definition_lists = true;
+                config
+            })
+            .build();
+        similar::TextDiff::from_lines(&without.to_string(), &with.to_string())
+            .unified_diff()
+            .to_string()
+    };
+    let source = indoc! {"
+        title 1
+          : definition 1
+
+        title 2
+          : definition 2 a
+          : definition 2 b
+    "};
+    let latex = diff(source, Config::latex());
+    insta::assert_snapshot!(latex, @r#"
+    @@ -3,8 +3,14 @@
+     │  INFO mdbook_pandoc::pandoc::renderer: Running pandoc    
+     │  INFO mdbook_pandoc::pandoc::renderer: Wrote output to book/latex/output.tex    
+     ├─ latex/output.tex
+    -│ title 1 : definition 1
+    +│ \begin{description}
+    +│ \tightlist
+    +│ \item[title 1]
+    +│ definition 1
+    +│ \item[title 2]
+    +│ definition 2 a
+     │ 
+    -│ title 2 : definition 2 a : definition 2 b
+    +│ definition 2 b
+    +│ \end{description}
+     ├─ latex/src/chapter.md
+    -│ [Para [Str "title 1", SoftBreak, Str ": definition 1"], Para [Str "title 2", SoftBreak, Str ": definition 2 a", SoftBreak, Str ": definition 2 b"]]
+    +│ [DefinitionList [([Str "title 1"], [[Plain [Str "definition 1"]]]), ([Str "title 2"], [[Plain [Str "definition 2 a"]], [Plain [Str "definition 2 b"]]])]]
+    "#);
+}
+
+#[test]
+fn dt_attributes() {
+    let source = indoc! {r#"
+        <dl>
+        <dt id="term1">term 1</dt>
+        <dd>definition 1</dd>
+        </dl>
+
+        [link to term 1](#term1)
+    "#};
+    let latex = MDBook::init()
+        .chapter(Chapter::new("", source, "chapter.md"))
+        .config(Config::latex())
+        .build();
+    insta::assert_snapshot!(latex, @r##"
+    ├─ log output
+    │  INFO mdbook::book: Running the pandoc backend    
+    │  INFO mdbook_pandoc::pandoc::renderer: Running pandoc    
+    │  INFO mdbook_pandoc::pandoc::renderer: Wrote output to book/latex/output.tex    
+    ├─ latex/output.tex
+    │ \begin{description}
+    │ \tightlist
+    │ \item[\phantomsection\label{book__latex__src__chapter.md__term1}{term 1}]
+    │ definition 1
+    │ \end{description}
+    │ 
+    │ \hyperref[book__latex__src__chapter.md__term1]{link to term 1}
+    ├─ latex/src/chapter.md
+    │ [DefinitionList [([Span ("term1", [], []) [Str "term 1"]], [[Plain [Str "definition 1"]]])], Plain [Str "
+    │ "], Para [Link ("", [], []) [Str "link to term 1"] ("#term1", "")]]
+    "##);
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -393,6 +393,7 @@ mod escaping;
 mod alerts;
 mod code;
 mod css;
+mod definition_lists;
 mod fonts;
 mod footnotes;
 mod headings;


### PR DESCRIPTION
Adds support for definition lists. For consistency with mdbook, this feature is disabled by default and must be explicitly enabled with the `output.pandoc.markdown.extensions.definition-lists` option.

```markdown
term 1
  : definition 1

term 2
  : definition 2 a
  : definition 2 b
```