### PR TITLE
change: match mdbook's log format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,6 +675,7 @@ version = "0.9.3"
 dependencies = [
  "aho-corasick",
  "anyhow",
+ "chrono",
  "cssparser",
  "ego-tree",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ include = ["/src", "!/src/tests", "/CHANGELOG.md", "/LICENSE-*", "/README.md"]
 [dependencies]
 aho-corasick = "1.0.0"
 anyhow = "1.0.47"
+chrono = { version = "0.4.24", default-features = false, features = ["clock"] }
 cssparser = "0.34.0"
 env_logger = "0.11.0"
 html5ever = "0.29.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,8 @@
-use std::{io, process};
+use std::{
+    env,
+    io::{self, Write},
+    process,
+};
 
 use anyhow::Context;
 use mdbook::Renderer;
@@ -11,12 +15,37 @@ fn main() {
 }
 
 fn try_main() -> anyhow::Result<()> {
-    env_logger::builder()
-        .filter_level(log::LevelFilter::Info)
-        .parse_default_env()
-        .init();
+    init_logger();
 
     let ctx = mdbook::renderer::RenderContext::from_json(io::stdin().lock())
         .context("unable to parse mdBook context")?;
     mdbook_pandoc::Renderer::new().render(&ctx)
+}
+
+// Adapted from mdbook's main.rs for consistency in log format
+fn init_logger() {
+    let mut builder = env_logger::Builder::new();
+
+    builder.format(|formatter, record| {
+        let style = formatter.default_level_style(record.level());
+        writeln!(
+            formatter,
+            "{} [{style}{}{style:#}] ({}): {}",
+            chrono::Local::now().format("%Y-%m-%d %H:%M:%S"),
+            record.level(),
+            record.target(),
+            record.args()
+        )
+    });
+
+    if let Ok(var) = env::var("RUST_LOG") {
+        builder.parse_filters(&var);
+    } else {
+        // if no RUST_LOG provided, default to logging at the Info level
+        builder.filter(None, log::LevelFilter::Info);
+        // Filter extraneous html5ever not-implemented messages
+        builder.filter(Some("html5ever"), log::LevelFilter::Error);
+    }
+
+    builder.init();
 }


### PR DESCRIPTION
```
2025-02-15 09:33:51 [INFO] (mdbook::book): Book building has started
2025-02-15 09:33:51 [INFO] (mdbook::book): Running the html backend
2025-02-15 09:33:51 [INFO] (mdbook::book): Running the pandoc backend
2025-02-15 09:33:51 [INFO] (mdbook::renderer): Invoking the "pandoc" renderer
2025-02-15 09:33:51 [INFO] (mdbook_pandoc::pandoc::renderer): Running pandoc
2025-02-15 09:33:53 [INFO] (mdbook_pandoc::pandoc::renderer): Wrote output to book/pandoc/pdf/book.pdf
```