### PR TITLE
feat: support superscripted and subscripted text

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ hosted-html = "https://doc.rust-lang.org/book" # URL of a HTML version of the bo
 gfm = false # enable pulldown-cmark's GitHub Flavored Markdown extensions
 math = false # parse inline ($a^b$) and display ($$a^b$$) math
 definition-lists = false # parse definition lists
+superscript = false # parse superscripted text (^this is superscripted^)
+subscript = false # parse subscripted text (~this is subscripted~)
 
 [output.pandoc.code]
 # Display hidden lines in code blocks (e.g., lines in Rust blocks prefixed by '#').
@@ -120,9 +122,11 @@ variable-name = "value"
   - [x] [Definition Lists](https://docs.rs/pulldown-cmark/0.13.0/pulldown_cmark/struct.Options.html#associatedconstant.ENABLE_DEFINITION_LIST)
     (Enable by setting `output.pandoc.markdown.extensions.definition-lists` to `true`)
 
-  - [ ] [Superscript](https://docs.rs/pulldown-cmark/0.13.0/pulldown_cmark/struct.Options.html#associatedconstant.ENABLE_SUPERSCRIPT)
+  - [x] [Superscript](https://docs.rs/pulldown-cmark/0.13.0/pulldown_cmark/struct.Options.html#associatedconstant.ENABLE_SUPERSCRIPT)
+    (Enable by setting `output.pandoc.markdown.extensions.superscript` to `true`)
 
-  - [ ] [Subscript](https://docs.rs/pulldown-cmark/0.13.0/pulldown_cmark/struct.Options.html#associatedconstant.ENABLE_SUBSCRIPT)
+  - [x] [Subscript](https://docs.rs/pulldown-cmark/0.13.0/pulldown_cmark/struct.Options.html#associatedconstant.ENABLE_SUBSCRIPT)
+    (Enable by setting `output.pandoc.markdown.extensions.subscript` to `true`)
 
 - [x] Table of contents
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,12 @@ struct MarkdownExtensionConfig {
     /// Enable [`pulldown_cmark::Options::ENABLE_DEFINITION_LIST`].
     #[serde(default = "defaults::disabled")]
     pub definition_lists: bool,
+    /// Enable [`pulldown_cmark::Options::ENABLE_SUPERSCRIPT`].
+    #[serde(default = "defaults::disabled")]
+    pub superscript: bool,
+    /// Enable [`pulldown_cmark::Options::ENABLE_SUBSCRIPT`].
+    #[serde(default = "defaults::disabled")]
+    pub subscript: bool,
 }
 
 /// Configuration for tweaking how code blocks are rendered.

--- a/src/pandoc/native.rs
+++ b/src/pandoc/native.rs
@@ -586,6 +586,28 @@ impl<'book, 'p, W: io::Write> SerializeInline<'_, 'book, 'p, W> {
         serializer.finish()
     }
 
+    /// Superscripted text (list of inlines)
+    pub fn serialize_superscript(
+        self,
+        inlines: impl FnOnce(&mut SerializeInlines<'_, 'book, 'p, W>) -> anyhow::Result<()>,
+    ) -> anyhow::Result<()> {
+        write!(self.serializer.unescaped(), "Superscript ")?;
+        let mut serializer = SerializeList::new(self.serializer, Inline)?;
+        inlines(&mut serializer)?;
+        serializer.finish()
+    }
+
+    /// Subscripted text (list of inlines)
+    pub fn serialize_subscript(
+        self,
+        inlines: impl FnOnce(&mut SerializeInlines<'_, 'book, 'p, W>) -> anyhow::Result<()>,
+    ) -> anyhow::Result<()> {
+        write!(self.serializer.unescaped(), "Subscript ")?;
+        let mut serializer = SerializeList::new(self.serializer, Inline)?;
+        inlines(&mut serializer)?;
+        serializer.finish()
+    }
+
     /// Inline code (literal)
     pub fn serialize_code(self, attrs: impl Attributes, code: &str) -> anyhow::Result<()> {
         write!(self.serializer.unescaped(), "Code ")?;

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -630,6 +630,8 @@ impl<'book> Parser<'book> {
                 gfm,
                 math,
                 definition_lists,
+                superscript,
+                subscript,
             } = extensions;
             if gfm {
                 options |= Options::ENABLE_GFM;
@@ -639,6 +641,12 @@ impl<'book> Parser<'book> {
             }
             if definition_lists {
                 options |= Options::ENABLE_DEFINITION_LIST;
+            }
+            if superscript {
+                options |= Options::ENABLE_SUPERSCRIPT;
+            }
+            if subscript {
+                options |= Options::ENABLE_SUBSCRIPT;
             }
             options
         };
@@ -898,7 +906,9 @@ impl<'book, 'preprocessor> PreprocessChapter<'book, 'preprocessor> {
                     Tag::CodeBlock(kind) => push_element(self, tree, MdElement::CodeBlock(kind)),
                     Tag::Emphasis => push_element(self, tree, MdElement::Emphasis),
                     Tag::Strong => push_element(self, tree, MdElement::Strong),
-                    Tag::Strikethrough => push_element(self, tree, MdElement::Strikethrough),
+                    Tag::Strikethrough => push_html_element(self, tree, local_name!("s")),
+                    Tag::Superscript => push_html_element(self, tree, local_name!("sup")),
+                    Tag::Subscript => push_html_element(self, tree, local_name!("sub")),
                     Tag::Image {
                         link_type,
                         dest_url,
@@ -924,8 +934,6 @@ impl<'book, 'preprocessor> PreprocessChapter<'book, 'preprocessor> {
                         }
                         return Ok(());
                     }
-                    // Not enabled
-                    Tag::Superscript | Tag::Subscript => unreachable!(),
                 }?;
                 Ok(())
             }

--- a/src/preprocess/tree.rs
+++ b/src/preprocess/tree.rs
@@ -497,13 +497,6 @@ impl<'book> Emitter<'book> {
                         })
                     })
                 }),
-                MdElement::Strikethrough => serializer.serialize_inlines(|inlines| {
-                    inlines.serialize_element()?.serialize_strikeout(|inlines| {
-                        inlines.serialize_nested(|serializer| {
-                            self.serialize_children(node, serializer)
-                        })
-                    })
-                }),
                 MdElement::InlineMath(math) => serializer.serialize_inlines(|inlines| {
                     inlines
                         .serialize_element()?
@@ -585,6 +578,35 @@ impl<'book> Emitter<'book> {
                                         self.serialize_children(node, serializer)
                                     })
                                 })
+                        })
+                    }
+                    local_name!("s") => {
+                        return serializer.serialize_inlines(|inlines| {
+                            inlines.serialize_element()?.serialize_strikeout(|inlines| {
+                                inlines.serialize_nested(|serializer| {
+                                    self.serialize_children(node, serializer)
+                                })
+                            })
+                        })
+                    }
+                    local_name!("sup") => {
+                        return serializer.serialize_inlines(|inlines| {
+                            inlines
+                                .serialize_element()?
+                                .serialize_superscript(|inlines| {
+                                    inlines.serialize_nested(|serializer| {
+                                        self.serialize_children(node, serializer)
+                                    })
+                                })
+                        })
+                    }
+                    local_name!("sub") => {
+                        return serializer.serialize_inlines(|inlines| {
+                            inlines.serialize_element()?.serialize_subscript(|inlines| {
+                                inlines.serialize_nested(|serializer| {
+                                    self.serialize_children(node, serializer)
+                                })
+                            })
                         })
                     }
                     local_name!("div") => {

--- a/src/preprocess/tree/node.rs
+++ b/src/preprocess/tree/node.rs
@@ -66,7 +66,6 @@ pub enum MdElement<'a> {
     },
     Emphasis,
     Strong,
-    Strikethrough,
     InlineMath(CowStr<'a>),
     DisplayMath(CowStr<'a>),
     Link {
@@ -237,10 +236,6 @@ impl MdElement<'_> {
             MdElement::Strong => {
                 const STRONG: &QualName = &html::name!(html "strong");
                 STRONG
-            }
-            MdElement::Strikethrough => {
-                const S: &QualName = &html::name!(html "s");
-                S
             }
             MdElement::Image { .. } => {
                 // <img> is a void element in HTML (can have no children),

--- a/src/tests/html.rs
+++ b/src/tests/html.rs
@@ -106,7 +106,11 @@ fn matched_html_tags() {
     // introduces newlines and breaks the original structure
     let output = MDBook::init()
         .config(Config::markdown())
-        .chapter(Chapter::new("Chapter", "2<sup>n - 1</sup>", "chapter.md"))
+        .chapter(Chapter::new(
+            "Chapter",
+            "he is <del>four</del><ins>five</ins> years old",
+            "chapter.md",
+        ))
         .build();
     insta::assert_snapshot!(output, @r"
     ├─ log output
@@ -114,7 +118,7 @@ fn matched_html_tags() {
     │  INFO mdbook_pandoc::pandoc::renderer: Running pandoc    
     │  INFO mdbook_pandoc::pandoc::renderer: Wrote output to book/markdown/book.md    
     ├─ markdown/book.md
-    │ 2`<sup>`{=html}n - 1`</sup>`{=html}
+    │ he is `<del>`{=html}four`</del>`{=html}`<ins>`{=html}five`</ins>`{=html} years old
     ");
 }
 
@@ -252,9 +256,9 @@ fn regression_malformed_html() {
         .config(Config::latex())
         .chapter(Chapter::new(
             "",
-            // These tags are mismatched (the second should be </sup> to close the first)
+            // These tags are mismatched (the second should be </del> to close the first)
             // but we should be able to handle this in a reasonable way
-            "**<sup>foo<sup>**",
+            "**<del>foo<del>**",
             "chapter.md",
         ))
         .build();
@@ -266,7 +270,7 @@ fn regression_malformed_html() {
     ├─ latex/output.tex
     │ \textbf{{foo}}
     ├─ latex/src/chapter.md
-    │ [Para [Strong [RawInline (Format "html") "<sup>", Span ("", [], []) [Str "foo", RawInline (Format "html") "<sup>", RawInline (Format "html") "</sup>"], RawInline (Format "html") "</sup>"]]]
+    │ [Para [Strong [RawInline (Format "html") "<del>", Span ("", [], []) [Str "foo", RawInline (Format "html") "<del>", RawInline (Format "html") "</del>"], RawInline (Format "html") "</del>"]]]
     "#);
 }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -402,6 +402,7 @@ mod images;
 mod links;
 mod math;
 mod redirects;
+mod super_sub;
 mod tables;
 
 mod books;

--- a/src/tests/super_sub.rs
+++ b/src/tests/super_sub.rs
@@ -1,0 +1,40 @@
+use indoc::indoc;
+
+use super::{Chapter, Config, MDBook};
+
+#[test]
+fn basic() {
+    let diff = |source: &str, mut config: Config| {
+        let chapter = Chapter::new("", source, "chapter.md");
+        let without = MDBook::init()
+            .chapter(chapter.clone())
+            .config(config.clone())
+            .build();
+        let with = MDBook::init()
+            .chapter(chapter)
+            .config({
+                config.markdown.extensions.superscript = true;
+                config.markdown.extensions.subscript = true;
+                config
+            })
+            .build();
+        similar::TextDiff::from_lines(&without.to_string(), &with.to_string())
+            .unified_diff()
+            .to_string()
+    };
+    let source = indoc! {r"
+        ^This is super^ ~This is sub~
+    "};
+    let latex = diff(source, Config::latex());
+    insta::assert_snapshot!(latex, @r#"
+    @@ -3,6 +3,6 @@
+     │  INFO mdbook_pandoc::pandoc::renderer: Running pandoc    
+     │  INFO mdbook_pandoc::pandoc::renderer: Wrote output to book/latex/output.tex    
+     ├─ latex/output.tex
+    -│ \^{}This is super\^{} \st{This is sub}
+    +│ \textsuperscript{This is super} \textsubscript{This is sub}
+     ├─ latex/src/chapter.md
+    -│ [Para [Str "^This is super^ ", Strikeout [Str "This is sub"]]]
+    +│ [Para [Superscript [Str "This is super"], Str " ", Subscript [Str "This is sub"]]]
+    "#);
+}


### PR DESCRIPTION
Adds support for superscripted and subscripted text. For consistency with mdbook, these features are disabled by default and must be enabled with the `output.pandoc.markdown.extensions.superscript` and `output.pandoc.markdown.extensions.subscript` options.

This change also adds support for `<sup>` and `<sub>` HTML elements, which does not require enabling the aforementioned config options.

```markdown
^This is superscripted^ ~This is subscripted~
```