### PR TITLE
fix: correctly generate TOC when nested chapters don't contain H1s

### DIFF
--- a/src/tests/headings.rs
+++ b/src/tests/headings.rs
@@ -55,6 +55,43 @@ fn nested_chapters() {
     ├─ latex/src/two.md
     │ [Header 1 ("two", [], []) [Str "Two"]]
     "#);
+
+    let book =
+        MDBook::init()
+            .chapter(Chapter::new("One", "# One", "one.md").child(
+                Chapter::new("One.One", "## Top\n### Another", "onepointone.md").child(
+                    Chapter::new("One.One.One", "### Top\n#### Another", "onepointoneone.md"),
+                ),
+            ))
+            .chapter(Chapter::new("Two", "# Two", "two.md"))
+            .config(Config::latex())
+            .build();
+    insta::assert_snapshot!(book, @r#"
+    ├─ log output
+    │  INFO mdbook::book: Running the pandoc backend    
+    │  INFO mdbook_pandoc::pandoc::renderer: Running pandoc    
+    │  INFO mdbook_pandoc::pandoc::renderer: Wrote output to book/latex/output.tex    
+    ├─ latex/output.tex
+    │ \chapter{One}\label{book__latex__src__one.md__one}
+    │ 
+    │ \section{Top}\label{book__latex__src__onepointone.md__top}
+    │ 
+    │ \subsection*{Another}\label{book__latex__src__onepointone.md__another}
+    │ 
+    │ \subsection{Top}\label{book__latex__src__onepointoneone.md__top}
+    │ 
+    │ \subsubsection*{Another}\label{book__latex__src__onepointoneone.md__another}
+    │ 
+    │ \chapter{Two}\label{book__latex__src__two.md__two}
+    ├─ latex/src/one.md
+    │ [Header 1 ("one", [], []) [Str "One"]]
+    ├─ latex/src/onepointone.md
+    │ [Header 2 ("top", [], []) [Str "Top"], Header 3 ("another", ["unnumbered", "unlisted"], []) [Str "Another"]]
+    ├─ latex/src/onepointoneone.md
+    │ [Header 3 ("top", [], []) [Str "Top"], Header 4 ("another", ["unnumbered", "unlisted"], []) [Str "Another"]]
+    ├─ latex/src/two.md
+    │ [Header 1 ("two", [], []) [Str "Two"]]
+    "#);
 }
 
 #[test]

--- a/src/tests/html.rs
+++ b/src/tests/html.rs
@@ -85,10 +85,7 @@ fn matched_html_tags() {
     │         [ Plain [ Str "\n" ]
     │         , Header
     │             2
-    │             ( "book__markdown__src__chapter.md__heading"
-    │             , [ "unnumbered" , "unlisted" ]
-    │             , []
-    │             )
+    │             ( "book__markdown__src__chapter.md__heading" , [] , [] )
     │             [ Str "Heading" ]
     │         , Para [ Str "text" ]
     │         ]
@@ -344,7 +341,7 @@ fn noscript_element() {
     │ , Header
     │     2
     │     ( "book__markdown__src__chapter.md__no-scripting-enabled"
-    │     , [ "unnumbered" , "unlisted" ]
+    │     , []
     │     , []
     │     )
     │     [ Str "No scripting enabled" ]


### PR DESCRIPTION
Currently, mdbook-pandoc only generates table of contents (TOC) entries for chapters that begin with an H1 (`# Chapter Heading`). Some books, such as the rust book, use proportionally smaller headings in nested chapters; for instance, chapter 1.1 begins with `## Installation`. In order to correctly generate TOCs for books that follow this style, this change adjusts heading levels based on the level of the first heading in each chapter, so chapter 1.1 is treated as if it began with `# Installation`.