### PR TITLE
feat: support using TeX macros across math inlines/blocks 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,6 +525,7 @@ checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ chrono = { version = "0.4.24", default-features = false, features = ["clock"] }
 cssparser = "0.35.0"
 env_logger = "0.11.0"
 html5ever = "0.31.0"
-indexmap = "2.7.0"
+indexmap = { version = "2.7.0", features = ["serde"] }
 log = "0.4.0"
 mdbook = { version = "0.4.35", default-features = false }
 normpath = "1.0.0"

--- a/src/latex.rs
+++ b/src/latex.rs
@@ -9,11 +9,11 @@ pub static MACRO_DEFINITION: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
         &[
             // \(re)newcommand
-            r"\\(?P<newcommand>(re)?newcommand) *(\\\w+|\{\\\w+\}) *(\[\d+\])* *\{.+\}",
+            r"\\((?P<newcommand>newcommand)|renewcommand) *(?P<command>\\\w+|\{\\\w+\}) *(?P<definition>(\[\d+\])* *\{.+\})",
             // \def
             r"\\def *\\\w+ *\{.+\}",
             // \let
-            r"\\let *\\\w+ *=? *(.|\\\w+)",
+            r"\\let *\\\w+ *(= *(\\\w+|\S)|(\\\w+|\S))",
         ]
         .join("|"),
     )

--- a/src/latex.rs
+++ b/src/latex.rs
@@ -1,5 +1,31 @@
 use std::collections::BTreeSet;
 
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+/// Commands that define new macros, as supported by MathJax:
+/// <https://docs.mathjax.org/en/latest/input/tex/macros.html>
+pub static MACRO_DEFINITION: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        &[
+            // \(re)newcommand
+            r"\\(?P<newcommand>(re)?newcommand) *(\\\w+|\{\\\w+\}) *(\[\d+\])* *\{.+\}",
+            // \def
+            r"\\def *\\\w+ *\{.+\}",
+            // \let
+            r"\\let *\\\w+ *=? *(.|\\\w+)",
+        ]
+        .join("|"),
+    )
+    .unwrap()
+});
+
+#[derive(Clone, Copy, Debug)]
+pub enum MathType {
+    Display,
+    Inline,
+}
+
 #[derive(Debug, Default)]
 pub struct Packages {
     needed: BTreeSet<Package>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,7 @@
-use std::{
-    collections::HashMap,
-    fs::{self, File},
-};
+use std::fs::{self, File};
 
 use anyhow::{anyhow, Context as _};
+use indexmap::IndexMap;
 use mdbook::config::HtmlConfig;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
@@ -23,7 +21,7 @@ use preprocess::Preprocessor;
 #[serde(rename_all = "kebab-case")]
 struct Config {
     #[serde(rename = "profile", default = "Default::default")]
-    pub profiles: HashMap<String, pandoc::Profile>,
+    pub profiles: IndexMap<String, pandoc::Profile>,
     #[serde(default = "defaults::enabled")]
     pub keep_preprocessed: bool,
     pub hosted_html: Option<String>,

--- a/src/pandoc/native.rs
+++ b/src/pandoc/native.rs
@@ -9,16 +9,14 @@ use html5ever::serialize::HtmlSerializer;
 use indexmap::IndexSet;
 use pulldown_cmark::CowStr;
 
-use crate::preprocess::{self, PreprocessChapter};
+use crate::{
+    latex::MathType,
+    preprocess::{self, PreprocessChapter},
+};
 
 use super::OutputFormat;
 
 pub mod escape;
-
-pub enum MathType {
-    Display,
-    Inline,
-}
 
 /// Alignment of a table column.
 pub enum Alignment {

--- a/src/preprocess/tree.rs
+++ b/src/preprocess/tree.rs
@@ -484,6 +484,13 @@ impl<'book> Emitter<'book> {
                             Ok(())
                         })
                 }
+                MdElement::RawInline { format, raw } => serializer.serialize_inlines(|inlines| {
+                    inlines
+                        .serialize_element()?
+                        .serialize_raw_inline(format, |serializer| {
+                            serializer.write_all(raw.as_bytes())
+                        })
+                }),
                 MdElement::Emphasis => serializer.serialize_inlines(|inlines| {
                     inlines.serialize_element()?.serialize_emph(|inlines| {
                         inlines.serialize_nested(|serializer| {

--- a/src/preprocess/tree.rs
+++ b/src/preprocess/tree.rs
@@ -498,15 +498,8 @@ impl<'book> Emitter<'book> {
                         })
                     })
                 }),
-                MdElement::InlineMath(math) => serializer.serialize_inlines(|inlines| {
-                    inlines
-                        .serialize_element()?
-                        .serialize_math(pandoc::native::MathType::Inline, math)
-                }),
-                MdElement::DisplayMath(math) => serializer.serialize_inlines(|inlines| {
-                    inlines
-                        .serialize_element()?
-                        .serialize_math(pandoc::native::MathType::Display, math)
+                MdElement::Math(kind, math) => serializer.serialize_inlines(|inlines| {
+                    inlines.serialize_element()?.serialize_math(*kind, math)
                 }),
                 MdElement::Image {
                     link_type,

--- a/src/preprocess/tree/node.rs
+++ b/src/preprocess/tree/node.rs
@@ -55,6 +55,10 @@ pub enum MdElement<'a> {
     BlockQuote(Option<BlockQuoteKind>),
     InlineCode(CowStr<'a>),
     CodeBlock(CodeBlockKind<'a>),
+    RawInline {
+        format: &'static str,
+        raw: CowStr<'a>,
+    },
     List(Option<u64>),
     Item,
     TaskListMarker(bool),
@@ -252,7 +256,7 @@ impl MdElement<'_> {
                 const INPUT: &QualName = &html::name!(html "input");
                 INPUT
             }
-            MdElement::Math(..) => {
+            MdElement::Math(..) | MdElement::RawInline { .. } => {
                 const SPAN: &QualName = &html::name!(html "span");
                 SPAN
             }

--- a/src/preprocess/tree/node.rs
+++ b/src/preprocess/tree/node.rs
@@ -4,7 +4,7 @@ use html5ever::{local_name, ns, tendril::StrTendril, Attribute, QualName};
 use indexmap::IndexMap;
 use pulldown_cmark::{Alignment, BlockQuoteKind, CodeBlockKind, CowStr, LinkType};
 
-use crate::html;
+use crate::{html, latex};
 
 /// A node in the tree.
 pub enum Node<'book> {
@@ -66,8 +66,7 @@ pub enum MdElement<'a> {
     },
     Emphasis,
     Strong,
-    InlineMath(CowStr<'a>),
-    DisplayMath(CowStr<'a>),
+    Math(latex::MathType, CowStr<'a>),
     Link {
         dest_url: CowStr<'a>,
         title: CowStr<'a>,
@@ -253,7 +252,7 @@ impl MdElement<'_> {
                 const INPUT: &QualName = &html::name!(html "input");
                 INPUT
             }
-            MdElement::InlineMath(_) | MdElement::DisplayMath(_) => {
+            MdElement::Math(..) => {
                 const SPAN: &QualName = &html::name!(html "span");
                 SPAN
             }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -359,6 +359,12 @@ impl Config {
         .unwrap()
     }
 
+    fn pdf_and_latex() -> Self {
+        let mut config = Self::pdf();
+        config.profiles.extend(Self::latex().profiles);
+        config
+    }
+
     fn markdown() -> Self {
         toml! {
             keep-preprocessed = false


### PR DESCRIPTION
To better emulate MathJax, allows using TeX macros that are defined in one math inline/block from other math inlines/blocks.