### PR TITLE
feat: Consider `output.html.site-url` when replace broken relative links

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,6 @@ A subset of the available options are described below:
 > Therefore, relative paths in the configuration (e.g. values for `include-in-header`, `reference-doc`) should be written relative to the book's root directory.
 
 ```toml
-[output.pandoc]
-hosted-html = "https://doc.rust-lang.org/book" # URL of a HTML version of the book
-
 [output.pandoc.markdown.extensions] # enable additional Markdown extensions
 gfm = false # enable pulldown-cmark's GitHub Flavored Markdown extensions
 math = false # parse inline ($a^b$) and display ($$a^b$$) math

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,11 @@ impl mdbook::Renderer for Renderer {
             // Preprocess book
             let mut preprocessor = Preprocessor::new(ctx, &cfg.markdown)?;
 
-            if let Some(uri) = cfg.hosted_html.as_deref() {
+            if let Some(uri) = cfg
+                .hosted_html
+                .as_deref()
+                .or(html_cfg.as_ref().and_then(|cfg| cfg.site_url.as_deref()))
+            {
                 preprocessor.hosted_html(uri);
             }
 
@@ -205,8 +209,8 @@ impl mdbook::Renderer for Renderer {
 
             if preprocessed.unresolved_links() {
                 log::warn!(
-                    "Unable to resolve one or more relative links within the book, \
-                    consider setting the `hosted-html` option in `[output.pandoc]`"
+                    "Failed to resolve one or more relative links within the book; \
+                    consider setting the `site-url` option in `[output.html]`"
                 );
             }
 

--- a/src/tests/books.rs
+++ b/src/tests/books.rs
@@ -10,10 +10,8 @@ static BOOKS: Lazy<PathBuf> = Lazy::new(|| Path::new(env!("CARGO_MANIFEST_DIR"))
 #[ignore]
 fn mdbook_guide() {
     let logs = MDBook::load(BOOKS.join("mdBook/guide"))
-        .config(Config {
-            hosted_html: Some("https://rust-lang.github.io/mdBook/".into()),
-            ..Config::pdf()
-        })
+        .config(Config::pdf())
+        .site_url("https://rust-lang.github.io/mdBook/")
         .build()
         .logs;
     insta::assert_snapshot!(logs);
@@ -25,10 +23,8 @@ fn cargo_book() {
     let logs = MDBook::options()
         .max_log_level(tracing::Level::DEBUG)
         .load(BOOKS.join("cargo/src/doc"))
-        .config(Config {
-            hosted_html: Some("https://doc.rust-lang.org/cargo/".into()),
-            ..Config::pdf()
-        })
+        .config(Config::pdf())
+        .site_url("https://doc.rust-lang.org/cargo/")
         .build()
         .logs;
     insta::assert_snapshot!(logs);
@@ -38,10 +34,8 @@ fn cargo_book() {
 #[ignore]
 fn rust_book() {
     let logs = MDBook::load(BOOKS.join("rust-book"))
-        .config(Config {
-            hosted_html: Some("https://doc.rust-lang.org/book/".into()),
-            ..Config::pdf()
-        })
+        .config(Config::pdf())
+        .site_url("https://doc.rust-lang.org/book/")
         .build()
         .logs;
     insta::assert_snapshot!(logs);
@@ -51,10 +45,8 @@ fn rust_book() {
 #[ignore]
 fn nomicon() {
     let logs = MDBook::load(BOOKS.join("nomicon"))
-        .config(Config {
-            hosted_html: Some("https://doc.rust-lang.org/nomicon/".into()),
-            ..Config::pdf()
-        })
+        .config(Config::pdf())
+        .site_url("https://doc.rust-lang.org/nomicon/")
         .build()
         .logs;
     insta::assert_snapshot!(logs);
@@ -64,10 +56,8 @@ fn nomicon() {
 #[ignore]
 fn rust_by_example() {
     let logs = MDBook::load(BOOKS.join("rust-by-example"))
-        .config(Config {
-            hosted_html: Some("https://doc.rust-lang.org/rust-by-example/".into()),
-            ..Config::pdf()
-        })
+        .config(Config::pdf())
+        .site_url("https://doc.rust-lang.org/rust-by-example/")
         .build()
         .logs;
     insta::assert_snapshot!(logs);
@@ -77,10 +67,8 @@ fn rust_by_example() {
 #[ignore]
 fn rust_edition_guide() {
     let logs = MDBook::load(BOOKS.join("rust-edition-guide"))
-        .config(Config {
-            hosted_html: Some("https://doc.rust-lang.org/edition-guide/".into()),
-            ..Config::pdf()
-        })
+        .config(Config::pdf())
+        .site_url("https://doc.rust-lang.org/edition-guide/")
         .build()
         .logs;
     insta::assert_snapshot!(logs);
@@ -90,10 +78,8 @@ fn rust_edition_guide() {
 #[ignore]
 fn rust_embedded() {
     let logs = MDBook::load(BOOKS.join("rust-embedded"))
-        .config(Config {
-            hosted_html: Some("https://docs.rust-embedded.org/book/".into()),
-            ..Config::pdf()
-        })
+        .config(Config::pdf())
+        .site_url("https://docs.rust-embedded.org/book/")
         .build()
         .logs;
     insta::assert_snapshot!(logs);
@@ -103,10 +89,8 @@ fn rust_embedded() {
 #[ignore]
 fn rust_reference() {
     let logs = MDBook::load(BOOKS.join("rust-reference"))
-        .config(Config {
-            hosted_html: Some("https://doc.rust-lang.org/reference/".into()),
-            ..Config::pdf()
-        })
+        .config(Config::pdf())
+        .site_url("https://doc.rust-lang.org/reference/")
         .build()
         .logs;
     insta::assert_snapshot!(logs);
@@ -116,10 +100,8 @@ fn rust_reference() {
 #[ignore]
 fn rustc_dev_guide() {
     let logs = MDBook::load(BOOKS.join("rustc-dev-guide"))
-        .config(Config {
-            hosted_html: Some("https://rustc-dev-guide.rust-lang.org/".into()),
-            ..Config::pdf()
-        })
+        .config(Config::pdf())
+        .site_url("https://rustc-dev-guide.rust-lang.org/")
         .build()
         .logs;
     insta::assert_snapshot!(logs);

--- a/src/tests/links.rs
+++ b/src/tests/links.rs
@@ -15,11 +15,29 @@ fn broken_links() {
     ├─ log output
     │  INFO mdbook::book: Running the pandoc backend    
     │  WARN mdbook_pandoc::preprocess: Unable to normalize link 'foobarbaz' in chapter 'Getting Started': Unable to normalize path: $ROOT/src/foobarbaz: No such file or directory (os error 2)    
-    │  WARN mdbook_pandoc: Unable to resolve one or more relative links within the book, consider setting the `hosted-html` option in `[output.pandoc]`    
+    │  WARN mdbook_pandoc: Failed to resolve one or more relative links within the book; consider setting the `site-url` option in `[output.html]`    
     │  INFO mdbook_pandoc::pandoc::renderer: Running pandoc    
     │  INFO mdbook_pandoc::pandoc::renderer: Wrote output to book/markdown/book.md    
     ├─ markdown/book.md
     │ [broken link](foobarbaz)
+    ");
+
+    let book = MDBook::init()
+        .chapter(Chapter::new(
+            "Getting Started",
+            "[broken link](foobarbaz)",
+            "getting-started.md",
+        ))
+        .site_url("example.com/book")
+        .build();
+    insta::assert_snapshot!(book, @r"
+    ├─ log output
+    │  INFO mdbook::book: Running the pandoc backend    
+    │  INFO mdbook_pandoc::preprocess: Failed to resolve link 'foobarbaz' in chapter 'getting-started.md', linking to hosted HTML book at 'example.com/book/foobarbaz'    
+    │  INFO mdbook_pandoc::pandoc::renderer: Running pandoc    
+    │  INFO mdbook_pandoc::pandoc::renderer: Wrote output to book/markdown/book.md    
+    ├─ markdown/book.md
+    │ [broken link](example.com/book/foobarbaz)
     ");
 }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -139,6 +139,11 @@ impl MDBook {
         self
     }
 
+    pub fn site_url(mut self, url: &str) -> Self {
+        self.book.config.set("output.html.site-url", url).unwrap();
+        self
+    }
+
     pub fn chapter(mut self, Chapter { mut chapter }: Chapter) -> Self {
         use mdbook::book::SectionNumber;
         let number = (self.book.book.sections.iter())


### PR DESCRIPTION
`output.pandoc.hosted_html` is redundant with `output.html.site-url`; consider the latter but continue supporting the former to avoid breakage