### PR TITLE
fix: percent-encode/decode links in Markdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
 
   msrv:
     runs-on: ubuntu-latest
-    container: foresterre/cargo-msrv:latest
+    container: foresterre/cargo-msrv:sha-a3857fa
     steps:
       - uses: actions/checkout@v4
       - name: Verify MSRV

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,6 +708,7 @@ dependencies = [
  "mdbook",
  "normpath",
  "once_cell",
+ "percent-encoding",
  "pulldown-cmark 0.13.0",
  "regex",
  "replace_with",
@@ -815,6 +816,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ tempfile = "3.0.0"
 toml = { version = "0.9.0", default-features = false, features = ["serde"] }
 utf8parse = "0.2.2"
 walkdir = "2.0.0"
+percent-encoding = "2.3.2"
 
 [dev-dependencies]
 indoc = "2.0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ mod css;
 mod html;
 mod latex;
 mod pandoc;
+mod url;
 
 mod preprocess;
 use preprocess::Preprocessor;

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -30,7 +30,7 @@ use walkdir::WalkDir;
 use crate::{
     latex,
     pandoc::{self, native::ColWidth, OutputFormat, RenderContext},
-    MarkdownConfig, MarkdownExtensionConfig,
+    url, MarkdownConfig, MarkdownExtensionConfig,
 };
 
 mod code;
@@ -909,11 +909,12 @@ impl<'book, 'preprocessor> PreprocessChapter<'book, 'preprocessor> {
                         title,
                         id: _,
                     } => {
-                        let dest_url = self.preprocessor.normalize_link_or_leave_as_is(
-                            self.chapter,
-                            link_type,
-                            dest_url,
-                        );
+                        let dest_url =
+                            url::encode(self.preprocessor.normalize_link_or_leave_as_is(
+                                self.chapter,
+                                link_type,
+                                url::best_effort_decode(dest_url),
+                            ));
                         push_element(self, tree, MdElement::Link { dest_url, title })
                     }
                     Tag::Paragraph => push_element(self, tree, MdElement::Paragraph),

--- a/src/tests/images.rs
+++ b/src/tests/images.rs
@@ -33,6 +33,34 @@ fn images() {
 }
 
 #[test]
+fn percent_encoding() {
+    let book = MDBook::init()
+        .config(Config::latex())
+        .file_in_src("img dir/image.png", "")
+        .chapter(Chapter::new(
+            "",
+            indoc! {r#"
+                ![](img%20dir/image.png)
+                <img src="img%20dir/image.png">
+            "#},
+            "chapter.md",
+        ))
+        .build();
+    insta::assert_snapshot!(book, @r#"
+    ├─ log output
+    │  INFO mdbook::book: Running the pandoc backend
+    │  INFO mdbook_pandoc::pandoc::renderer: Running pandoc
+    │  INFO mdbook_pandoc::pandoc::renderer: Wrote output to book/latex/output.tex
+    ├─ latex/output.tex
+    │ \pandocbounded{\includegraphics[keepaspectratio]{book/latex/src/img dir/image.png}}
+    │ \pandocbounded{\includegraphics[keepaspectratio]{book/latex/src/img dir/image.png}}
+    ├─ latex/src/chapter.md
+    │ [Para [Image ("", [], []) [] ("book/latex/src/img%20dir/image.png", ""), SoftBreak, Image ("", [], []) [] ("book/latex/src/img%20dir/image.png", "")]]
+    ├─ latex/src/img dir/image.png
+    "#);
+}
+
+#[test]
 #[ignore]
 fn remote_images() {
     let book = MDBook::init()

--- a/src/tests/links.rs
+++ b/src/tests/links.rs
@@ -136,3 +136,32 @@ fn inter_chapter_links() {
     │ [Header 1 ("two", [], []) [Str "Two"], Para [Link ("", [], []) [Str "One"] ("book/latex/src/one/one.md#one", ""), SoftBreak, Link ("", [], []) [Str "also one"] ("book/latex/src/one/one.md#one", ""), SoftBreak, Link ("", [], []) [Str "Three"] ("../three.md", "")]]
     "#);
 }
+
+#[test]
+fn percent_encoding() {
+    let book = MDBook::init()
+        .chapter(Chapter::new(
+            "One",
+            "# One\n[Two](../two/chapter%20two.md)",
+            "one/one.md",
+        ))
+        .chapter(Chapter::new("Two", "# Two", "two/chapter two.md"))
+        .config(Config::latex())
+        .build();
+    insta::assert_snapshot!(book, @r#"
+    ├─ log output
+    │  INFO mdbook::book: Running the pandoc backend
+    │  INFO mdbook_pandoc::pandoc::renderer: Running pandoc
+    │  INFO mdbook_pandoc::pandoc::renderer: Wrote output to book/latex/output.tex
+    ├─ latex/output.tex
+    │ \chapter{One}\label{book__latex__src__one__one.md__one}
+    │ 
+    │ \hyperref[book__latex__src__two__chapter-two.md__two]{Two}
+    │ 
+    │ \chapter{Two}\label{book__latex__src__two__chapter-two.md__two}
+    ├─ latex/src/one/one.md
+    │ [Header 1 ("one", [], []) [Str "One"], Para [Link ("", [], []) [Str "Two"] ("book/latex/src/two/chapter%20two.md#two", "")]]
+    ├─ latex/src/two/chapter two.md
+    │ [Header 1 ("two", [], []) [Str "Two"]]
+    "#);
+}

--- a/src/tests/redirects.rs
+++ b/src/tests/redirects.rs
@@ -13,8 +13,8 @@ fn redirects() {
 
         [output.html.redirect]
         "/appendices/bibliography.html" = "https://rustc-dev-guide.rust-lang.org/appendix/bibliography.html"
-        "/foo/bar.html" = "../new-bar.html"
-        "/new-bar.html" = "new-new-bar.html"
+        "/foo/bar.html" = "../new bar.html"
+        "/new bar.html" = "new new-bar.html"
     "#};
     let output = MDBook::options()
         .max_log_level(tracing::Level::DEBUG)
@@ -25,7 +25,7 @@ fn redirects() {
             "[bar](foo/bar.md)\n[bib](appendices/bibliography.html)",
             "index.md",
         ))
-        .chapter(Chapter::new("", "# New New Bar", "new-new-bar.md"))
+        .chapter(Chapter::new("", "# New New Bar", "new new-bar.md"))
         .build();
     insta::assert_snapshot!(output, @r#"
     ├─ log output
@@ -34,11 +34,11 @@ fn redirects() {
     │  INFO mdbook::book: Running the pandoc backend
     │ DEBUG mdbook_pandoc: Processing redirects in [output.html.redirect]
     │ DEBUG mdbook_pandoc::preprocess: Processing redirect: /appendices/bibliography.html => https://rustc-dev-guide.rust-lang.org/appendix/bibliography.html
-    │ DEBUG mdbook_pandoc::preprocess: Processing redirect: /foo/bar.html => ../new-bar.html
-    │ DEBUG mdbook_pandoc::preprocess: Processing redirect: /new-bar.html => new-new-bar.html
+    │ DEBUG mdbook_pandoc::preprocess: Processing redirect: /foo/bar.html => ../new bar.html
+    │ DEBUG mdbook_pandoc::preprocess: Processing redirect: /new bar.html => new new-bar.html
     │ DEBUG mdbook_pandoc::preprocess: Registered redirect: book/test/src/appendices/bibliography.html => https://rustc-dev-guide.rust-lang.org/appendix/bibliography.html
-    │ DEBUG mdbook_pandoc::preprocess: Registered redirect: book/test/src/foo/bar.html => book/test/src/new-bar.html
-    │ DEBUG mdbook_pandoc::preprocess: Registered redirect: book/test/src/new-bar.html => book/test/src/new-new-bar.md#new-new-bar
+    │ DEBUG mdbook_pandoc::preprocess: Registered redirect: book/test/src/foo/bar.html => book/test/src/new bar.html
+    │ DEBUG mdbook_pandoc::preprocess: Registered redirect: book/test/src/new bar.html => book/test/src/new new-bar.md#new-new-bar
     │ DEBUG mdbook_pandoc::preprocess: Preprocessing ''
     │ DEBUG mdbook_pandoc::preprocess: Preprocessing ''
     │  INFO mdbook_pandoc::pandoc::renderer: Running pandoc
@@ -46,9 +46,9 @@ fn redirects() {
     ├─ test/src/appendices/bibliography.html
     ├─ test/src/foo/bar.html
     ├─ test/src/index.md
-    │ [Para [Link ("", [], []) [Str "bar"] ("book/test/src/new-new-bar.md#new-new-bar", ""), SoftBreak, Link ("", [], []) [Str "bib"] ("https://rustc-dev-guide.rust-lang.org/appendix/bibliography.html", "")]]
-    ├─ test/src/new-bar.html
-    ├─ test/src/new-new-bar.md
+    │ [Para [Link ("", [], []) [Str "bar"] ("book/test/src/new%20new-bar.md#new-new-bar", ""), SoftBreak, Link ("", [], []) [Str "bib"] ("https://rustc-dev-guide.rust-lang.org/appendix/bibliography.html", "")]]
+    ├─ test/src/new bar.html
+    ├─ test/src/new new-bar.md
     │ [Header 1 ("new-new-bar", [], []) [Str "New New Bar"]]
     "#)
 }

--- a/src/url.rs
+++ b/src/url.rs
@@ -1,0 +1,35 @@
+use std::borrow::Cow;
+
+use pulldown_cmark::CowStr;
+
+pub(crate) fn best_effort_decode(s: CowStr<'_>) -> CowStr<'_> {
+    match s {
+        CowStr::Borrowed(borrowed) => percent_encoding::percent_decode_str(borrowed)
+            .decode_utf8()
+            .map_or(s, CowStr::from),
+        _ => match percent_encoding::percent_decode_str(&s).decode_utf8() {
+            Ok(Cow::Borrowed(_)) => s,
+            Ok(Cow::Owned(s)) => s.into(),
+            Err(_) => s,
+        },
+    }
+}
+
+/// Percent-encode a string to be usable as a URI (matching Javascript's [`encodeURI()`]).
+///
+/// [`encodeURI()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI#description
+pub(crate) fn encode(s: CowStr<'_>) -> CowStr<'_> {
+    #[rustfmt::skip]
+    const PERCENT_ENCODING: &percent_encoding::AsciiSet = &percent_encoding::NON_ALPHANUMERIC
+        .remove(b'-').remove(b'_').remove(b'.').remove(b'!').remove(b'~').remove(b'*').remove(b'\'').remove(b'(').remove(b')')
+        // Characters that may be part of the URI syntax
+        .remove(b';').remove(b'/').remove(b'?').remove(b':').remove(b'@').remove(b'&').remove(b'=').remove(b'+').remove(b'$').remove(b',').remove(b'#');
+    let encoded = match s {
+        CowStr::Borrowed(s) => percent_encoding::utf8_percent_encode(s, PERCENT_ENCODING),
+        _ => percent_encoding::utf8_percent_encode(&s, PERCENT_ENCODING),
+    };
+    match Cow::from(encoded) {
+        Cow::Borrowed(_) => s,
+        Cow::Owned(s) => s.into(),
+    }
+}


### PR DESCRIPTION
This makes it possible to e.g. use spaces in filenames.

Closes #209