### PR TITLE
feat: add options to number and list (in ToC) internal headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ A subset of the available options are described below:
 > Therefore, relative paths in the configuration (e.g. values for `include-in-header`, `reference-doc`) should be written relative to the book's root directory.
 
 ```toml
+[output.pandoc]
+number-internal-headings = false # number headings inside of chapters
+list-internal-headings = false # list internal headings in the table of contents
+
 [output.pandoc.markdown.extensions] # enable additional Markdown extensions
 math = false # parse inline ($a^b$) and display ($$a^b$$) math
 superscript = false # parse superscripted text (^this is superscripted^)

--- a/src/tests/code.rs
+++ b/src/tests/code.rs
@@ -1,6 +1,6 @@
 use indoc::indoc;
 
-use super::{Chapter, CodeConfig, Config, MDBook};
+use super::{Chapter, Config, MDBook};
 
 #[test]
 fn code_escaping() {
@@ -103,11 +103,10 @@ fn code_block_with_hidden_lines() {
     │ ```
     "#);
     let book = MDBook::init()
-        .config(Config {
-            code: CodeConfig {
-                show_hidden_lines: true,
-            },
-            ..Config::markdown()
+        .config({
+            let mut config = Config::markdown();
+            config.common.code.show_hidden_lines = true;
+            config
         })
         .chapter(Chapter::new("", content, "chapter.md"))
         .build();
@@ -167,11 +166,10 @@ fn non_rust_code_block_with_hidden_lines() {
     ");
     let book = MDBook::init()
         .mdbook_config(cfg.parse().unwrap())
-        .config(Config {
-            code: CodeConfig {
-                show_hidden_lines: true,
-            },
-            ..Config::markdown()
+        .config({
+            let mut config = Config::markdown();
+            config.common.code.show_hidden_lines = true;
+            config
         })
         .chapter(Chapter::new("", content, "chapter.md"))
         .build();

--- a/src/tests/math.rs
+++ b/src/tests/math.rs
@@ -15,7 +15,7 @@ fn math() {
         let with = MDBook::init()
             .chapter(chapter)
             .config({
-                config.markdown.extensions.math = true;
+                config.common.markdown.extensions.math = true;
                 config
             })
             .build();

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -14,7 +14,7 @@ use tempfile::{tempfile, TempDir};
 use toml::toml;
 use tracing_subscriber::layer::SubscriberExt;
 
-use crate::{CodeConfig, Config, Renderer};
+use crate::{Config, Renderer};
 
 pub struct MDBook {
     book: mdbook_driver::MDBook,

--- a/src/tests/super_sub.rs
+++ b/src/tests/super_sub.rs
@@ -13,8 +13,8 @@ fn basic() {
         let with = MDBook::init()
             .chapter(chapter)
             .config({
-                config.markdown.extensions.superscript = true;
-                config.markdown.extensions.subscript = true;
+                config.common.markdown.extensions.superscript = true;
+                config.common.markdown.extensions.subscript = true;
                 config
             })
             .build();


### PR DESCRIPTION
Adds options to number internal headings (non-top-level headings inside of chapters) and include them in the table of contents. To match mdbook, the default remains that internal headings are unnumbered and unlisted.

```toml
[output.pandoc]
number-internal-headings = false
list-internal-headings = false
```