### PR TITLE
fix: CRLF line endings in code blocks

### DIFF
--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -606,7 +606,10 @@ pub struct PreprocessChapter<'book, 'preprocessor> {
 
 struct Parser<'book> {
     lookahead: VecDeque<(Event<'book>, Range<usize>)>,
-    parser: pulldown_cmark::OffsetIter<'book, pulldown_cmark::DefaultBrokenLinkCallback>,
+    parser: pulldown_cmark::utils::TextMergeWithOffset<
+        'book,
+        pulldown_cmark::OffsetIter<'book, pulldown_cmark::DefaultBrokenLinkCallback>,
+    >,
 }
 
 impl<'book> Parser<'book> {
@@ -652,7 +655,9 @@ impl<'book> Parser<'book> {
 
         Self {
             lookahead: Default::default(),
-            parser: pulldown_cmark::Parser::new_ext(md, options).into_offset_iter(),
+            parser: pulldown_cmark::utils::TextMergeWithOffset::new(
+                pulldown_cmark::Parser::new_ext(md, options).into_offset_iter(),
+            ),
         }
     }
 

--- a/src/tests/alerts.rs
+++ b/src/tests/alerts.rs
@@ -33,7 +33,7 @@ fn alerts() {
      │ Highlights information that users should take into account, even when skimming.
     -│ \end{quote}
      ├─ latex/src/chapter.md
-    -│ [BlockQuote [Para [Str "[", Str "!NOTE", Str "]", LineBreak, Str "Highlights information that users should take into account, even when skimming."]]]
+    -│ [BlockQuote [Para [Str "[!NOTE]", LineBreak, Str "Highlights information that users should take into account, even when skimming."]]]
     +│ [Div ("", ["note"], []) [Div ("", ["title"], []) [Para [Str "Note"]], Para [Str "Highlights information that users should take into account, even when skimming."]]]
     "#);
     let markdown = diff(alert, Config::markdown());

--- a/src/tests/code.rs
+++ b/src/tests/code.rs
@@ -357,3 +357,33 @@ fn regression_inline_code_newline() {
     │ ]
     "#);
 }
+
+/// Ensures that CRLF line endings in code blocks do not add extra empty lines (issue #231)
+#[test]
+fn crlf_line_endings() {
+    let book = MDBook::init()
+        .config(Config::pandoc())
+        .chapter(Chapter::new(
+            "",
+            indoc! {"
+                ```
+                fn main() {\n}
+                ```
+                ```
+                fn main() {\r\n}
+                ```
+            "},
+            "chapter.md",
+        ))
+        .build();
+    insta::assert_snapshot!(book, @r#"
+    ├─ log output
+    │  INFO mdbook_driver::mdbook: Running the pandoc backend
+    │  INFO mdbook_pandoc::pandoc::renderer: Running pandoc
+    │  INFO mdbook_pandoc::pandoc::renderer: Wrote output to book/markdown/pandoc-ir
+    ├─ markdown/pandoc-ir
+    │ [ CodeBlock ( "" , [ "" ] , [] ) "fn main() {\n}\n"
+    │ , CodeBlock ( "" , [ "" ] , [] ) "fn main() {\n}\n"
+    │ ]
+    "#);
+}

--- a/src/tests/escaping.rs
+++ b/src/tests/escaping.rs
@@ -12,15 +12,6 @@ fn preserve_escapes() {
     │  INFO mdbook_pandoc::pandoc::renderer: Running pandoc
     │  INFO mdbook_pandoc::pandoc::renderer: Wrote output to book/markdown/pandoc-ir
     ├─ markdown/pandoc-ir
-    │ [ Para
-    │     [ Str "["
-    │     , Str "Prefix @fig:1"
-    │     , Str "]"
-    │     , Str " "
-    │     , Str "["
-    │     , Str "-@fig:1"
-    │     , Str "]"
-    │     ]
-    │ ]
+    │ [ Para [ Str "[Prefix @fig:1] [-@fig:1]" ] ]
     "#);
 }

--- a/src/tests/math.rs
+++ b/src/tests/math.rs
@@ -59,7 +59,7 @@ fn math() {
     -│ inline \$a\^{}b\$ math
     +│ inline \(a^b\) math
      ├─ latex/src/chapter.md
-    -│ [Para [Str "$$I(x)=I_0e^{-ax}", Str "\\another line$$"], Para [Str "$$", SoftBreak, Str "\\begin{cases}", SoftBreak, Str "\\frac 1 2 ", Str "\\", SoftBreak, Str "\\frac 3 4", SoftBreak, Str "5", SoftBreak, Str "\\end{cases}", SoftBreak, Str "$$"], Para [Str "inline $a^b$ math"]]
+    -│ [Para [Str "$$I(x)=I_0e^{-ax}\\another line$$"], Para [Str "$$", SoftBreak, Str "\\begin{cases}", SoftBreak, Str "\\frac 1 2 \\", SoftBreak, Str "\\frac 3 4", SoftBreak, Str "5", SoftBreak, Str "\\end{cases}", SoftBreak, Str "$$"], Para [Str "inline $a^b$ math"]]
     +│ [Para [Math DisplayMath "I(x)=I_0e^{-ax}\\\\another line"], Para [Math DisplayMath "
     +│ \\begin{cases}
     +│     \\frac 1 2 \\\\


### PR DESCRIPTION
Previously, CRLF line endings in code blocks would add two line breaks instead of one.

Fixes #231